### PR TITLE
Correctly specify module name for 'shake' executable.

### DIFF
--- a/Development/Make/Main.hs
+++ b/Development/Make/Main.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RecordWildCards, PatternGuards, CPP #-}
 
-module Development.Make.Main(main) where
+module Main(main) where
 
 import System.Environment
 import Development.Shake


### PR DESCRIPTION
This fixes a critical problem in the `shake` executable distributed with `shake-0.10`: it doesn't specify the correct module name for the `Main` module. Without this, the build fails like so:

```
$ cabal install -j1
Resolving dependencies...
Configuring shake-0.10...
Building shake-0.10...
Preprocessing executable 'shake' for shake-0.10...
[ 1 of 31] Compiling Paths_shake      ( dist/build/autogen/Paths_shake.hs, dist/build/shake/shake-tmp/Paths_shake.o )
...
[31 of 31] Compiling Development.Make.Main ( Development/Make/Main.hs, dist/build/shake/shake-tmp/Development/Make/Main.o )
Warning: output was redirected with -o, but no output will be generated
because there is no Main module.
Preprocessing library shake-0.10...
[ 1 of 27] Compiling Development.Shake.Errors ( Development/Shake/Errors.hs, dist/build/Development/Shake/Errors.o )
...
Documentation created: dist/doc/html/shake/index.html
Installing library in /home/a/.cabal/lib/shake-0.10/ghc-7.4.2
Installing executable(s) in /home/a/.cabal/bin
cabal: dist/build/shake/shake: does not exist
Failed to install shake-0.10
cabal: Error: some packages failed to install:
shake-0.10 failed during the final install step. The exception was:
ExitFailure 1
$ 
```

I'd suggest merging and releasing `shake-0.11` ASAP.
