### PR TITLE
Export ShakeException type

### DIFF
--- a/Development/Shake.hs
+++ b/Development/Shake.hs
@@ -78,7 +78,7 @@ module Development.Shake(
     -- ** Verbosity
     Verbosity(..), getVerbosity, putLoud, putNormal, putQuiet, quietly,
     -- * Error Handling
-    ShakeException, innerException,
+    ShakeException(..),
     -- * Utility functions
     module Development.Shake.Derived,
     removeFiles, removeFilesAfter,

--- a/Development/Shake/Errors.hs
+++ b/Development/Shake/Errors.hs
@@ -2,7 +2,7 @@
 
 -- | Errors seen by the user
 module Development.Shake.Errors(
-    ShakeException(..), innerException,
+    ShakeException(..),
     errorNoRuleToBuildType, errorRuleTypeMismatch, errorIncompatibleRules,
     errorMultipleRulesMatch, errorRuleRecursion,
     err
@@ -107,14 +107,11 @@ isOracle t = con `elem` ["OracleQ","OracleA"]
 -- | All foreseen exception conditions thrown by Shake, such problems with the rules or errors when executing
 --   rules, will be raised using this exception type.
 data ShakeException = ShakeException
-        [String] -- Entries on the stack, starting at the top of the stack.
-        SomeException -- Inner exception that was raised.
-        -- If I make these Haddock comments, then Haddock dies
-    deriving Typeable
-
--- | Inner exception that was raised.
-innerException :: ShakeException -> SomeException
-innerException (ShakeException _ inner) = inner
+  { backtrace :: [String]
+    -- ^ Entries on the stack, starting at the top of the stack.
+  , innerException :: SomeException
+    -- ^ Inner exception that was raised.
+  } deriving Typeable
 
 instance Exception ShakeException
 


### PR DESCRIPTION
Without this export it is very difficult to handle exceptions thrown by Shake.  I'm using Shake as a library inside another library, so this is an important issue for me.

This patch does not export the constructor and only provides a utility function to extract the underlying exception, so you're relatively free to change the internals in the future.
