### PR TITLE
added (~>) infix operator alias for 'phony'

### DIFF
--- a/Development/Shake.hs
+++ b/Development/Shake.hs
@@ -86,7 +86,7 @@ module Development.Shake(
     module Development.Shake.Derived,
     removeFiles, removeFilesAfter,
     -- * File rules
-    need, want, (*>), (**>), (?>), phony,
+    need, want, (*>), (**>), (?>), phony, (~>),
     module Development.Shake.Files,
     FilePattern, (?==),
     -- * Directory rules

--- a/Development/Shake/File.hs
+++ b/Development/Shake/File.hs
@@ -3,7 +3,7 @@
 module Development.Shake.File(
     need, want,
     defaultRuleFile,
-    (*>), (**>), (?>), phony,
+    (*>), (**>), (?>), phony, (~>),
     newCache, newCacheIO
     ) where
 
@@ -22,7 +22,7 @@ import Development.Shake.FileTime
 import System.FilePath(takeDirectory) -- important that this is the system local filepath, or wrong slashes go wrong
 
 
-infix 1 *>, ?>, **>
+infix 1 *>, ?>, **>, ~>
 
 
 newtype FileQ = FileQ BSU
@@ -140,6 +140,11 @@ phony name act = rule $ \(FileQ x_) -> let x = unpackU x_ in
     if name /= x then Nothing else Just $ do
         act
         return $ FileA fileTimeNone
+
+-- | Infix operator alias for 'phony', for sake of consistency with normal
+--   rules.
+(~>) :: String -> Action () -> Rules ()
+(~>) = phony 
 
 
 -- | Define a rule to build files. If the first argument returns 'True' for a given file,


### PR DESCRIPTION
Discussion: https://github.com/ndmitchell/shake/issues/35

Main motivation is DSL consistency with normal rule `*>` operator.

**(Contrived) Usage:**

```
-- Normal rule
"article.pdf" *> \_ -> do
  need ["article.md"]
  cmd "pandoc" ["-o","article.pdf","article.md"]

-- Phony rule
"render"      ~> do
  need ["article.pdf"]
  cmd "echo" ["rendered."]
```

Choice of `(~>)` was more or less arbitrary
