### PR TITLE
fix incorrect serialization of long BinLists

### DIFF
--- a/General/Binary.hs
+++ b/General/Binary.hs
@@ -37,7 +37,7 @@ instance Show a => Show (BinList a) where show = show . fromBinList
 instance Binary a => Binary (BinList a) where
     put (BinList xs) = case splitAt 254 xs of
         (a, []) -> putWord8 (genericLength xs) >> mapM_ put xs
-        (a, b) -> putWord8 255 >> mapM_ put xs >> put (BinList b)
+        (a, b) -> putWord8 255 >> mapM_ put a >> put (BinList b)
     get = do
         x <- getWord8
         case x of


### PR DESCRIPTION
BinLists with more than 254 elements are supposed to be serialized as:
- The byte `255`
- The first 254 elements of the list
- The serialized version of the remainder of the list, from the 255th element onward

They are currently serialized incorrectly as:
- The byte `255`
- _All_ elements of the list
- The serialized version of the remainder of the list, from the 255th element onward

The resulting bytestrings can't be deserialized correctly.  In particular, I found that the lists of dependencies for some rules were being truncated during deserialization, which broke incremental builds - if a rule made more than 254 calls to `need`, it would not be rebuilt on incremental builds if only dependencies from the 255th and later `need`s were modified.
