### PR TITLE
build.sh needs -threaded for -qg and -qb

### DIFF
--- a/docs/manual/build.sh
+++ b/docs/manual/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 mkdir -p _shake
-ghc --make Build.hs -rtsopts "-with-rtsopts=-I0 -qg -qb" -outputdir=_shake -o _shake/build && _shake/build "$@"
+ghc --make Build.hs -threaded -rtsopts "-with-rtsopts=-I0 -qg -qb" -outputdir=_shake -o _shake/build && _shake/build "$@"


### PR DESCRIPTION
without this I get:

Linking _shake/build ...
build: the flag -qg requires the program to be built with -threaded
build: the flag -qb requires the program to be built with -threaded

This change is probably needed for build.bat too, but I don't use Win so didn't test.
