### PR TITLE
Development/Shake/Rules/Directory.hs: enable FlexibleContexts in implicit type sigs

### DIFF
--- a/Development/Shake/Rules/Directory.hs
+++ b/Development/Shake/Rules/Directory.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, GeneralizedNewtypeDeriving, ScopedTypeVariables, DeriveDataTypeable, RecordWildCards #-}
+{-# LANGUAGE MultiParamTypeClasses, GeneralizedNewtypeDeriving, ScopedTypeVariables, DeriveDataTypeable, RecordWildCards, FlexibleContexts #-}
 
 -- | Both System.Directory and System.Environment wrappers
 module Development.Shake.Rules.Directory(


### PR DESCRIPTION
> [36 of 41] Compiling Development.Shake.Rules.Directory (
> Development/Shake/Rules/Directory.hs,
> dist/dist-sandbox-48f3b19e/build/Development/Shake/Rules/Directory.o )
> 
> Development/Shake/Rules/Directory.hs:205:1:
>     Non type-variable argument
>       in the constraint: Rule key GetDirectoryA
>     (Use FlexibleContexts to permit this)
>     In the context: (Rule key GetDirectoryA)
>     While checking the inferred type for ‘getDirAction’

Fixes build failure on current ghc-HEAD due to: 
http://permalink.gmane.org/gmane.comp.lang.haskell.glasgow.user/24612

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
