### PR TITLE
Add `cmd` examples to illustrate arguments.

### DIFF
--- a/src/Development/Shake/Command.hs
+++ b/src/Development/Shake/Command.hs
@@ -458,7 +458,17 @@ type a :-> t = a
 --
 -- * 'CmdOption' arguments are used as options.
 --
---   To take the examples from 'command':
+--   Example arguments and the resulting command string:
+--
+-- @
+-- 'cmd' \"git log --pretty=\" \"oneline\"        -> \"git log --pretty= oneline\"
+-- 'cmd' \"git log --pretty=\" [\"oneline\"]      -> \"git log --pretty= oneline\"
+-- 'cmd' \"git log\" (\"--pretty=\" ++ \"oneline\") -> \"git log --pretty=oneline\"
+-- 'cmd' \"git log\" (\"--pretty=\" ++ \"one line\") -> \"git log --pretty=one line\"
+-- 'cmd' \"git log\" [\"--pretty=\" ++ \"one line\"] -> \"git log --pretty=one\ line\"
+-- @
+--
+--   More examples, including return values, see this translation of the examples given for the 'command' function:
 --
 -- @
 -- () <- 'cmd' \"gcc -c myfile.c\"                                  -- compile a file, throwing an exception on failure


### PR DESCRIPTION
In the Google group thread I said I'd like to add examples of using the `cmd` function. I don't know how to preview the output of these docs. Any tips? Or perhaps it is fine with a look-over from you?