### PR TITLE
Normalise paths reported by fsatrace, whitelist ~/.cabal and ~/Applications

### DIFF
--- a/src/Development/Shake/Command.hs
+++ b/src/Development/Shake/Command.hs
@@ -203,8 +203,8 @@ fsatraceFiles file = do
     xs <- parseFSAT <$> readFileUTF8 file
     let reader (FSATRead x) = Just x; reader _ = Nothing
         writer (FSATWrite x) = Just x; writer (FSATMove x y) = Just x; writer _ = Nothing
-    frs <- liftIO $ filterM doesFileExist $ nubOrd $ mapMaybe reader xs
-    fws <- liftIO $ filterM doesFileExist $ nubOrd $ mapMaybe writer xs
+    frs <- liftIO $ filterM doesFileExist $ nubOrd $ map normalise $ mapMaybe reader xs
+    fws <- liftIO $ filterM doesFileExist $ nubOrd $ map normalise $ mapMaybe writer xs
     return (frs, fws)
 
 
@@ -224,6 +224,8 @@ unixWhitelist = do
     home <- getEnv "HOME"
     return [home ++ "/.ghc"
            ,home ++ "/Library/Haskell"
+           ,home ++ "/Applications"
+           ,home ++ "/.cabal"
            ,"/Applications"
            ,"/var/folders"
            ,"/usr"


### PR DESCRIPTION
With this patch the test suite passes when running under fsatrace.