### PR TITLE
Drop redundant constraints that are warned by GHC HEAD

### DIFF
--- a/src/Development/Shake/Core.hs
+++ b/src/Development/Shake/Core.hs
@@ -172,10 +172,10 @@ class (
 
 data ARule m = forall key value . Rule key value => ARule (key -> Maybe (m value))
 
-ruleKey :: Rule key value => (key -> Maybe (m value)) -> key
+ruleKey :: (key -> Maybe (m value)) -> key
 ruleKey = err "ruleKey"
 
-ruleValue :: Rule key value => (key -> Maybe (m value)) -> value
+ruleValue :: (key -> Maybe (m value)) -> value
 ruleValue = err "ruleValue"
 
 

--- a/src/Development/Shake/Storage.hs
+++ b/src/Development/Shake/Storage.hs
@@ -54,7 +54,7 @@ splitVersion abc = (a `LBS.append` b, c)
 
 
 withStorage
-    :: (Show w, Show k, Show v, Eq w, Eq k, Hashable k
+    :: (Show k, Show v, Eq w, Eq k, Hashable k
        ,Binary w, BinaryWith w k, BinaryWith w v)
     => ShakeOptions             -- ^ Storage options
     -> (String -> IO ())        -- ^ Logging function


### PR DESCRIPTION
This makes `cabal build` warning free with `ghc-7.11.20150422`