### PR TITLE
Rule names may contain dots.

### DIFF
--- a/src/Development/Ninja/Lexer.hs
+++ b/src/Development/Ninja/Lexer.hs
@@ -139,7 +139,7 @@ lexBind c_x | (c,x) <- list0 c_x = case c of
 
 lexBuild x
     | (outputs,x) <- lexxExprs True x
-    , (rule,x) <- span0 isVar $ dropSpace x
+    , (rule,x) <- span0 isVarDot $ dropSpace x
     , (deps,x) <- lexxExprs False $ dropSpace x
     = LexBuild outputs rule deps : lexerLoop x
 


### PR DESCRIPTION
After very recent changes in CVS LLVM/Clang, cmake generated ninja project (perhaps make variant is vulnerable too) can't be built by shake. The patch proposed fixes things for me.