### PR TITLE
Cycle through a precalculated random bools in nonDet

### DIFF
--- a/src/Development/Shake/Pool.hs
+++ b/src/Development/Shake/Pool.hs
@@ -22,10 +22,11 @@ import System.Random
 -- Monad for non-deterministic (but otherwise pure) computations
 type NonDet a = IO a
 
+rnds :: [Bool]
+rnds = map (unsafePerformIO . const randomIO) [0..99]
+
 nonDet :: NonDet [Bool]
-nonDet = do bs <- unsafeInterleaveIO nonDet
-            b <- randomIO
-            return $ b:bs
+nonDet = return $ cycle rnds
 
 -- Left = deterministic list, Right = non-deterministic tree
 data Queue a = Queue [a] (Either [a] (Maybe (Tree a)))


### PR DESCRIPTION
I'm getting excessive allocation/times in `nonDet` in empty builds (taking more than `getFileInfo`). Something like this seems to improve the situation.