### PR TITLE
Fix UTF-8 encoded output

### DIFF
--- a/src/Development/Shake/Types.hs
+++ b/src/Development/Shake/Types.hs
@@ -11,6 +11,7 @@ import Data.List
 import Development.Shake.Progress
 import Development.Shake.FilePattern
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.UTF8 as UTF8
 import Development.Shake.CmdOption
 
 
@@ -162,7 +163,7 @@ shakeOptions = ShakeOptions
     ".shake" 1 "1" Normal False [] Nothing [] [] [] (Just 10) Nothing [] False True False
     True ChangeModtime True [] False
     (const $ return ())
-    (const $ BS.putStrLn . BS.pack) -- try and output atomically using BS
+    (const $ BS.putStrLn . UTF8.fromString) -- try and output atomically using BS
 
 fieldsShakeOptions =
     ["shakeFiles", "shakeThreads", "shakeVersion", "shakeVerbosity", "shakeStaunch", "shakeReport"


### PR DESCRIPTION
The default `shakeOutput` handler just naively packed the `String` to be
printed into a `ByteString`, truncating non-ASCII characters. Fix this
by properly encoding the `String`.

Fixes #364.