### PR TITLE
Implement storedValueE which supports 'NeverRecomp'.

### DIFF
--- a/src/Development/Shake/Core.hs
+++ b/src/Development/Shake/Core.hs
@@ -147,7 +147,7 @@ class (ShakeValue key, ShakeValue value) => Rule key value where
     storedValueE opts k
         = maybe AlwaysRecomp RecompIfNotEq `fmap` storedValue opts k
 
-    -- | Like 'storeValueE', but this method does not have the ability
+    -- | Like 'storedValueE', but this method does not have the ability
     -- to return 'NeverRecomp'.  For backwards-compatibility.
     storedValue :: ShakeOptions -> key -> IO (Maybe value)
     storedValue opts k = do

--- a/src/Development/Shake/Rule.hs
+++ b/src/Development/Shake/Rule.hs
@@ -3,6 +3,7 @@
 --   Most users will find the built-in set of rules sufficient.
 module Development.Shake.Rule(
     Rule(..), EqualCost(..), rule, apply, apply1,
+    MaybeStored(..),
     trackUse, trackChange, trackAllow,
     -- * Deprecated
     defaultRule
@@ -10,6 +11,7 @@ module Development.Shake.Rule(
 
 import Development.Shake.Core
 import Development.Shake.Types
+import Development.Shake.Database
 
 {-# DEPRECATED defaultRule "Use 'rule' with 'priority' 0" #-}
 


### PR DESCRIPTION
This commit introduces a new method to 'Rule', 'storedValueE',
whose return type is extended to be 'MaybeStored', a data type
that can reports 'AlwaysRecomp' (previously 'Nothing'),
'RecompIfNotEq' (previously 'Just') and 'NeverRecomp' (new!)
'NeverRecomp' causes Shake to treat the value stored for the
rule in the database as canonical; the rule will only be compiled
if (1) there was no value in the database to begin with, or
(2) dependencies changed.

See discussion in #191 (and #185).  This architectural extension
makes it possible to write oracle rules which do NOT always
rerun, although I haven't added any porcelain for that.

Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
