### PR TITLE
Refactored copyFileChanged to extract whenFilesDifer

### DIFF
--- a/src/Development/Shake.hs
+++ b/src/Development/Shake.hs
@@ -111,6 +111,7 @@ module Development.Shake(
     -- * Explicit parallelism
     parallel, forP, par,
     -- * Utility functions
+    whenFilesDifer,
     copyFile', copyFileChanged,
     readFile', readFileLines,
     writeFile', writeFileLines, writeFileChanged,

--- a/src/Development/Shake/Command.hs
+++ b/src/Development/Shake/Command.hs
@@ -44,7 +44,7 @@ import Development.Shake.FilePath
 import Development.Shake.FilePattern
 import Development.Shake.Types
 import Development.Shake.Rules.File
-import Development.Shake.Derived(writeFile', withTempDir)
+import Development.Shake.Derived(writeFile', withTempDir, withTempFile)
 
 ---------------------------------------------------------------------
 -- ACTUAL EXECUTION
@@ -559,12 +559,6 @@ instance Arg a => Arg (Maybe a) where arg = maybe [] arg
 
 ---------------------------------------------------------------------
 -- UTILITIES
-
--- Copied from Derived. Once Derived no longer exports cmd stuff, import from there.
-withTempFile :: (FilePath -> Action a) -> Action a
-withTempFile act = do
-    (file, del) <- liftIO newTempFile
-    act file `actionFinally` del
 
 -- A better version of showCommandForUser, which doesn't escape so much on Windows
 showCommandForUser2 :: FilePath -> [String] -> String

--- a/src/Test/Docs.hs
+++ b/src/Test/Docs.hs
@@ -91,6 +91,7 @@ main = shaken (\a b -> unless brokenHaddock $ noTest a b) $ \args obj -> do
             ,"remaining = 1.1"
             ,"done = 1.1"
             ,"time_elapsed = 1.1"
+            ,"act = undefined"
             ,"old = \"\""
             ,"new = \"\""
             ,"myfile = \"\""


### PR DESCRIPTION
I also removed what seems to be a leftover `withTempFile`.
Note that `copyFileChanged` isn't exactly equivalent since it won't perform the `need` when the file doesn't exist. Is that a problem?
