### PR TITLE
Use displayException for prettier errors when possible

### DIFF
--- a/src/Development/Shake/Errors.hs
+++ b/src/Development/Shake/Errors.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, PatternGuards, RecordWildCards #-}
+{-# LANGUAGE DeriveDataTypeable, PatternGuards, RecordWildCards, CPP #-}
 
 -- | Errors seen by the user
 module Development.Shake.Errors(
@@ -141,4 +141,8 @@ instance Show ShakeException where
     show ShakeException{..} = unlines $
         "Error when running Shake build system:" :
         map ("* " ++) shakeExceptionStack ++
+#if MIN_VERSION_base(4,8,0)
+        [displayException shakeExceptionInner]
+#else
         [show shakeExceptionInner]
+#endif


### PR DESCRIPTION
Apparently this function has been a part of the `Exception` typeclass [since base 4.8](https://hackage.haskell.org/package/base-4.9.0.0/docs/Control-Exception-Base.html#v:displayException).