### PR TITLE
More descriptive error when trying to `need` a directory

### DIFF
--- a/src/Development/Shake/FileInfo.hs
+++ b/src/Development/Shake/FileInfo.hs
@@ -108,7 +108,7 @@ getFileInfo x = BS.useAsCString (unpackU_ x) $ \file ->
         let peek = do
                 code <- peekFileAttributes fad
                 if testBit code 4 then
-                    errorIO $ "Shake error: getFileInfo, expected a file, got a directory: " ++ unpackU x ++ ". Possible cause: you're calling `need` on a directory. Shake only allows you to `need` a file."
+                    errorIO $ "Shake error: getFileInfo, expected a file, got a directory: " ++ unpackU x ++ ". Possible cause: you're calling `need` on a directory. Shake only allows you to `need` files."
                  else
                     join $ liftM2 result (peekLastWriteTimeLow fad) (peekFileSizeLow fad)
         if res then

--- a/src/Development/Shake/FileInfo.hs
+++ b/src/Development/Shake/FileInfo.hs
@@ -108,7 +108,7 @@ getFileInfo x = BS.useAsCString (unpackU_ x) $ \file ->
         let peek = do
                 code <- peekFileAttributes fad
                 if testBit code 4 then
-                    errorIO $ "getFileInfo, expected a file, got a directory: " ++ unpackU x
+                    errorIO $ "Shake error: getFileInfo, expected a file, got a directory: " ++ unpackU x ++ ". Possible cause: you're calling `need` on a directory. Shake only allows you to `need` a file."
                  else
                     join $ liftM2 result (peekLastWriteTimeLow fad) (peekFileSizeLow fad)
         if res then


### PR DESCRIPTION
Related to #431

I was getting this error, and it took me a while to understand the cause. Hopefully a more detailed error will make it easier for users.

(In my case, it was especially confusing because I was editing legacy code that was abusing `need` to generate directories. When I upgraded by repo to use the current master version of Shake, I started getting this error.)