### PR TITLE
Update demo and manual to use Stack GHC

### DIFF
--- a/docs/Demo.md
+++ b/docs/Demo.md
@@ -5,6 +5,7 @@ To get started with Shake, you need to:
 * Install the [Haskell Stack](http://haskellstack.org/).
 * Type `stack install shake`
 * Run `stack exec -- shake --demo`, which should produce something similar to the trace below.
+* To repeat the build after the initial demo, run `stack exec ./build.sh` in the demo directory.
 
 <pre>
 <!-- nosyntax --><b>% Welcome to the Shake v1.0 demo mode!

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -288,7 +288,7 @@ As shown before, we can use `runhaskell Build.hs` to execute our build system, b
 
 This script creates a folder named `_shake` for the build system objects to live in, then runs `ghc --make Build.hs` to produce `_shake/build`, then executes `_shake/build` with all arguments it was given. The `-with-rtsopts` flag instructs the Haskell compiler to disable "idle garbage collection", making more CPU available for the commands you are running, as [explained here](http://stackoverflow.com/questions/34588057/why-does-shake-recommend-disabling-idle-garbage-collection/).
 
-Now you can run a build by simply typing `./build.sh` on Linux, or `build` on Windows. On Linux you may want to alias `build` to `./build.sh`. For the rest of this document we will assume `build` runs the build system.
+Now you can run a build by simply typing `stack exec ./build.sh` on Linux, or `stack exec build` on Windows. On Linux you may want to alias `build` to `stack exec ./build.sh`. For the rest of this document we will assume `build` runs the build system.
 
 _Warning:_ You should not use the `-threaded` for GHC 7.6 or below because of a [GHC bug](https://ghc.haskell.org/trac/ghc/ticket/7646). If you do turn on `-threaded`, you should include `-qg -qb` in `-with-rtsopts`. 
 


### PR DESCRIPTION
Since the docs recommend installing Shake with stack, a raw command to
ghc will likely fail due to missing libraries if a user tries to re-run
the Shake demo after the initial `stack exec -- shake --demo` cmd.