### PR TITLE
Add test on file that can't exist

### DIFF
--- a/shake.cabal
+++ b/shake.cabal
@@ -379,6 +379,7 @@ test-suite shake-test
         Test.Directory
         Test.Docs
         Test.Errors
+        Test.Existence
         Test.FileLock
         Test.FilePath
         Test.FilePattern

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -25,6 +25,7 @@ import qualified Test.Digest as Digest
 import qualified Test.Directory as Directory
 import qualified Test.Docs as Docs
 import qualified Test.Errors as Errors
+import qualified Test.Existence as Existence
 import qualified Test.FileLock as FileLock
 import qualified Test.Files as Files
 import qualified Test.FilePath as FilePath
@@ -61,7 +62,9 @@ fakes = ["clean" * clean, "test" * test, "make" * makefile, "filetime" * filetim
 mains = ["tar" * Tar.main, "self" * Self.main, "c" * C.main
         ,"basic" * Basic.main, "cache" * Cache.main, "command" * Command.main
         ,"config" * Config.main, "digest" * Digest.main, "directory" * Directory.main
-        ,"docs" * Docs.main, "errors" * Errors.main, "orderonly" * OrderOnly.main
+        ,"docs" * Docs.main
+        ,"errors" * Errors.main, "existence" * Existence.main
+        ,"orderonly" * OrderOnly.main
         ,"filepath" * FilePath.main, "filepattern" * FilePattern.main, "files" * Files.main, "filelock" * FileLock.main
         ,"forward" * Forward.main, "match" * Match.main
         ,"journal" * Journal.main, "lint" * Lint.main, "live" * Live.main, "manual" * Manual.main

--- a/src/Test/Existence.hs
+++ b/src/Test/Existence.hs
@@ -19,9 +19,9 @@ main _ = do
 assertIsJust :: IO (Maybe a) -> IO ()
 assertIsJust action = do
     Just _ <- action
-    pure ()
+    return ()
 
 assertIsNothing :: IO (Maybe a) -> IO ()
 assertIsNothing action = do
     Nothing <- action
-    pure ()
+    return ()

--- a/src/Test/Existence.hs
+++ b/src/Test/Existence.hs
@@ -1,0 +1,27 @@
+module Test.Existence(main) where
+
+import           Development.Shake                   (getDirectoryFilesIO)
+import           Development.Shake.Internal.FileInfo (getFileInfo)
+import           Development.Shake.Internal.FileName (fileNameFromString)
+import           System.Directory                    (getCurrentDirectory)
+import           System.FilePath                     ((</>))
+
+main :: IO () -> IO ()
+main _ = do
+    cwd <- getCurrentDirectory
+    someFiles <- getDirectoryFilesIO cwd ["*"]
+    let someFile = head someFiles
+    assertIsJust . getFileInfo $ fileNameFromString someFile
+
+    let fileThatCantExist = someFile </> "fileThatCantExist"
+    assertIsNothing . getFileInfo $ fileNameFromString fileThatCantExist
+
+assertIsJust :: IO (Maybe a) -> IO ()
+assertIsJust action = do
+    Just _ <- action
+    pure ()
+
+assertIsNothing :: IO (Maybe a) -> IO ()
+assertIsNothing action = do
+    Nothing <- action
+    pure ()


### PR DESCRIPTION
If file doesn't exist, `getFileInfo` must return `Nothing`.

Why I need this: I want to build executable `myexe` and run tests with phony `myexe/test`.