### PR TITLE
Don't store new FileQs if nothing changed

### DIFF
--- a/src/Development/Shake/Internal/Rules/File.hs
+++ b/src/Development/Shake/Internal/Rules/File.hs
@@ -234,7 +234,7 @@ ruleRun opts@ShakeOptions{..} rebuildFlags o@(FileQ x) oldBin@(fmap getEx -> old
             case now of
                 Nothing -> rebuild
                 Just now -> case fileEqualValue opts old now of
-                    EqualCheap -> retNew ChangedNothing $ ResultDirect now
+                    EqualCheap -> retOld ChangedNothing
                     EqualExpensive -> retNew ChangedStore $ ResultDirect now
                     NotEqual -> rebuild
         Just (ResultForward old) | not dirtyChildren -> retOld ChangedNothing


### PR DESCRIPTION
Storing the new FileQ was forcing all of the hash thunks.

I'm quite unfamiliar with shake, so apologies if I'm mistaken. I saw that all files were being hashed while profiling hadrian. I verified by `putStrLn`-instrumenting the `unsafeInterleaveIO` thunk in `fileStoreValue`. This speeds up a no-op hadrian run by about 15% (-j1, and profiled).

Sorry there's no test, I wasn't up to working out how the testing framework works.