### PR TITLE
Retrofit Semigroup instances

### DIFF
--- a/src/Development/Shake/Command.hs
+++ b/src/Development/Shake/Command.hs
@@ -586,7 +586,7 @@ cmd_ = cmd
 
 -- | The arguments to 'cmd' - see 'cmd' for examples and semantics.
 newtype CmdArgument = CmdArgument [Either CmdOption String]
-  deriving (Eq, Monoid, Show)
+  deriving (Eq, Semigroup, Monoid, Show)
 
 -- | The arguments to 'cmd' - see 'cmd' for examples and semantics.
 class CmdArguments t where

--- a/src/Development/Shake/Internal/Core/Rules.hs
+++ b/src/Development/Shake/Internal/Core/Rules.hs
@@ -102,6 +102,9 @@ data SRules = SRules
     ,userRules :: !(Map.HashMap TypeRep{-k-} UserRule_)
     }
 
+instance Semigroup SRules where
+  (<>) = mappend
+
 instance Monoid SRules where
     mempty = SRules mempty Map.empty Map.empty
     mappend (SRules x1 x2 x3) (SRules y1 y2 y3) = SRules (mappend x1 y1) (Map.unionWithKey f x2 y2) (Map.unionWith g x3 y3)
@@ -112,6 +115,8 @@ instance Monoid SRules where
             fromUnordered (Unordered xs) = xs
             fromUnordered x = [x]
 
+instance Monoid a => Semigroup (Rules a) where
+    (<>) = mappend
 
 instance Monoid a => Monoid (Rules a) where
     mempty = return mempty

--- a/src/Development/Shake/Internal/Progress.hs
+++ b/src/Development/Shake/Internal/Progress.hs
@@ -67,6 +67,9 @@ data Progress = Progress
     }
     deriving (Eq,Ord,Show,Read,Data,Typeable)
 
+instance Semigroup Progress where
+    (<>) = mappend
+
 instance Monoid Progress where
     mempty = Progress Nothing 0 0 0 0 0 0 0 (0,0)
     mappend a b = Progress

--- a/src/General/Bilist.hs
+++ b/src/General/Bilist.hs
@@ -19,6 +19,9 @@ isEmpty (Bilist as bs) = null as && null bs
 instance Eq a => Eq (Bilist a) where
     a == b = toList a == toList b
 
+instance Semigroup (Bilist a) where
+    (<>) = mappend
+
 instance Monoid (Bilist a) where
     mempty = Bilist [] []
     mappend a b = Bilist (toList a ++ toList b) []

--- a/src/General/Binary.hs
+++ b/src/General/Binary.hs
@@ -68,6 +68,9 @@ sizeBuilder (Builder i _) = i
 runBuilder :: Builder -> BS.ByteString
 runBuilder (Builder i f) = unsafePerformIO $ BS.create i $ \ptr -> f ptr 0
 
+instance Semigroup Builder where
+    (<>) = mappend
+
 instance Monoid Builder where
     mempty = Builder 0 $ \_ _ -> return ()
     mappend (Builder x1 x2) (Builder y1 y2) = Builder (x1+y1) $ \p i -> do x2 p i; y2 p $ i+x1

--- a/src/General/ListBuilder.hs
+++ b/src/General/ListBuilder.hs
@@ -3,6 +3,7 @@ module General.ListBuilder(
     ListBuilder, runListBuilder, newListBuilder
     ) where
 
+import Data.Semigroup
 import Data.Monoid
 import Prelude()
 
@@ -10,6 +11,9 @@ data ListBuilder a
     = Zero
     | One a
     | Add (ListBuilder a) (ListBuilder a)
+
+instance Semigroup (ListBuilder a) where
+    (<>) = mappend
 
 instance Monoid (ListBuilder a) where
     mempty = Zero


### PR DESCRIPTION
where necessary to conform with recent GHC's
Semigroup-Monoid-Proposal.

Fix for issue #554.

Precondition for merging: needs `cabal` dependency on `semigroups` package for GHCs that do not bring it with themselves (e.g. base < 4.9)