### PR TITLE
Reword error message for when a rule didn't produce the file

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -17,7 +17,7 @@ Error when running Shake build system:
 * stack_element1.txt
 * stack_eLement2.txt
 * real_file.o
-Error, rule failed to build file:
+Error, rule finished running but did not produce file:
   real_rile.o
 ```
 

--- a/src/Development/Shake/Internal/Rules/File.hs
+++ b/src/Development/Shake/Internal/Rules/File.hs
@@ -276,7 +276,7 @@ ruleRun opts@ShakeOptions{..} rebuildFlags o@(FileQ x) oldBin@(fmap getEx -> old
                     answer ResultForward =<< act
                 Just (ModeDirect act) -> do
                     act
-                    new <- liftIO $ storedValueError opts False "Error, rule failed to build file:" o
+                    new <- liftIO $ storedValueError opts False "Error, rule finished running but did not produce file:" o
                     case new of
                         Nothing -> retNew ChangedRecomputeDiff ResultPhony
                         Just new -> answer ResultDirect new

--- a/src/Development/Shake/Internal/Rules/Files.hs
+++ b/src/Development/Shake/Internal/Rules/Files.hs
@@ -206,6 +206,6 @@ getFileTimes name xs = do
         Nothing | not $ shakeCreationCheck opts -> return $ FilesA []
         Nothing -> do
             let missing = length $ filter isNothing ys
-            error $ "Error, " ++ name ++ " rule failed to build " ++ show missing ++
+            error $ "Error, " ++ name ++ " rule failed to produce " ++ show missing ++
                     " file" ++ (if missing == 1 then "" else "s") ++ " (out of " ++ show (length xs) ++ ")" ++
                     concat ["\n  " ++ fileNameToString x ++ if isNothing y then " - MISSING" else "" | (FileQ x,y) <- zip xs ys]


### PR DESCRIPTION
The previous message was sometimes confusing, especially to a sloppy
reader like me. I often skim the error message and assume that
the rule encountered an error while executing, details of which are
to be found elsewhere.