### PR TITLE
Print --help message at Quiet instead of Normal

### DIFF
--- a/src/Development/Shake/Internal/Args.hs
+++ b/src/Development/Shake/Internal/Args.hs
@@ -138,7 +138,7 @@ shakeArgsOptionsWith baseOpts userOptions rules = do
     let putWhenLn v msg = putWhen v $ msg ++ "\n"
     let showHelp = do
             progName <- getProgName
-            putWhen Normal $ unlines $ ("Usage: " ++ progName ++ " [options] [target] ...") : "Options:" : showOptDescr opts
+            putWhen Quiet $ unlines $ ("Usage: " ++ progName ++ " [options] [target] ...") : "Options:" : showOptDescr opts
 
     when (errs /= []) $ do
         putWhen Quiet $ unlines $ map ("shake: " ++) $ filter (not . null) $ lines $ unlines errs


### PR DESCRIPTION
Otherwise it's confusing if you default to Quiet and --help doesn't seem to
work.  Presumably if someone explicitly asked for it, they want to see it,
unless they also asked for Silent.