### PR TITLE
Add semigroup instance for Action

### DIFF
--- a/src/Development/Shake/Internal/Core/Types.hs
+++ b/src/Development/Shake/Internal/Core/Types.hs
@@ -27,6 +27,10 @@ import Development.Shake.Internal.Options
 import General.Cleanup
 import Prelude
 
+#if __GLASGOW_HASKELL__ < 840
+import Data.Semigroup
+#endif
+
 #if __GLASGOW_HASKELL__ >= 800
 import Control.Monad.Fail
 #endif
@@ -45,6 +49,16 @@ newtype Action a = Action {fromAction :: RAW Global Local a}
 #endif
         )
 
+instance Semigroup a => Semigroup (Action a) where
+    (<>) a b = (<>) <$> a <*> b
+
+instance Monoid a => Monoid (Action a) where
+    mempty = pure mempty
+#if __GLASGOW_HASKELL__ < 840
+    mappend a b = mappend <$> a <*> b
+#endif
+
+-- | How has a rule changed.
 -- | How has a rule changed.
 data RunChanged
     = ChangedNothing -- ^ Nothing has changed.


### PR DESCRIPTION
This would add `Semigroup` and `Monoid` instances for `Action`, keeping compatibility with past compiler versions. 