### PR TITLE
Print "Build completed" message with millisecond accuracy

### DIFF
--- a/src/Development/Shake/Internal/Args.hs
+++ b/src/Development/Shake/Internal/Args.hs
@@ -204,8 +204,11 @@ shakeArgsOptionsWith baseOpts userOptions rules = do
                 Right () -> do
                     tot <- start
                     let (mins,secs) = divMod (ceiling tot) (60 :: Int)
-                        time = show mins ++ ":" ++ ['0' | secs < 10] ++ show secs
-                    putWhenLn Normal $ esc "32" $ "Build completed in " ++ time ++ "m"
+                        millis = ceiling (1000 * (tot - fromIntegral (floor tot)))
+                        time = if tot < 60
+                            then show (floor tot) ++ "." ++ ['0' | millis < 10] ++ ['0' | millis < 100] ++ show millis ++ "s"
+                            else show mins ++ ":" ++ ['0' | secs < 10] ++ show secs ++ "." ++ show millis ++ "m"
+                    putWhenLn Normal $ esc "32" $ "Build completed in " ++ time
     where
         opts = removeOverlap userOptions (map snd shakeOptsEx) `mergeOptDescr` userOptions
 


### PR DESCRIPTION
This changes the "Build completed" message.

If the time is at least one minute then the output remains the same:

```
Build completed in 2:34m
```

But if the time is less than one minute then the output has millisecond accuracy:

```
Build completed in 12.624s
```

```
Build completed in 0.057s
```

This added accuracy is useful when you are optimizing the zero build of your build system