### PR TITLE
Adds known to allow checking for unknown targets

### DIFF
--- a/src/Development/Shake.hs
+++ b/src/Development/Shake.hs
@@ -103,6 +103,7 @@ module Development.Shake(
     needHasChanged,
     resultHasChanged,
     batch,
+    known,
     -- * Deprecated
     (*>), (|*>), (&*>),
     (**>), (*>>), (?>>),

--- a/src/Test/Basic.hs
+++ b/src/Test/Basic.hs
@@ -80,6 +80,10 @@ main = shakeTest_ test $ do
 
     "rerun" %> \out -> do alwaysRerun; liftIO $ appendFile out "."
 
+    let checkKnown file = \out -> do alwaysRerun; ok <- known file; writeFile' out $ if ok then "True" else "False"
+    "check-rerun" %> checkKnown "rerun"
+    "check-slartibartfass" %> checkKnown "slartibartfass"
+
     phony "foo" $
         liftIO $ createDirectoryRecursive "foo"
 
@@ -208,3 +212,9 @@ test build = do
     assertContents "order.log" "YX"
     build ["ordering"]
     assertContents "order.log" "YXYX"
+
+    build ["check-rerun"]
+    assertContents "check-rerun" "True"
+
+    build ["check-slartibartfass"]
+    assertContents "check-slartibartfass" "False"


### PR DESCRIPTION
Using known one can implement a check for files, which can be build by
a rule database. With this information one can delete files, not buildable
by a shake build system. Hopefully those are stale artifacts

To elaborate: Under a bunch of assumptions, one can implement a rule to delete stale targets.
For example: Consider a build system, which starts with an empty build directory and each file, which is created there, is created by a rule within the shake build system. In this case one can check every file in the build directory with known and delete those, that aren't known any more.

An approximation could have been implemented by needing all the files in the build directory again, but then they also would be rebuild, if they are out of date and the build would stop for each unknown file und you would have to reiterate.

Maybe if known is a to great risk to add to the official api, one could place it in a Development.Shake.Experimental module and state, that such a module contains parts of the api with a high probability of changing or evening disappearing.

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
