### PR TITLE
Add: getTargets :: ShakeOptions -> Rules () -> IO [String]

### DIFF
--- a/shake.cabal
+++ b/shake.cabal
@@ -448,6 +448,7 @@ test-suite shake-test
         Test.FilePattern
         Test.Files
         Test.Forward
+        Test.GetTargets
         Test.History
         Test.Journal
         Test.Lint

--- a/src/Development/Ninja/All.hs
+++ b/src/Development/Ninja/All.hs
@@ -5,7 +5,7 @@ module Development.Ninja.All(runNinja) where
 import Development.Ninja.Env
 import Development.Ninja.Type
 import Development.Ninja.Parse
-import Development.Shake hiding (addEnv)
+import Development.Shake hiding (addEnv,build)
 import Development.Shake.Classes
 import qualified Data.ByteString as BS8
 import qualified Data.ByteString.Char8 as BS

--- a/src/Development/Shake.hs
+++ b/src/Development/Shake.hs
@@ -62,6 +62,8 @@ module Development.Shake(
     getShakeExtra, getShakeExtraRules, addShakeExtra,
     -- ** Command line
     shakeArgs, shakeArgsWith, shakeArgsOptionsWith, shakeOptDescrs,
+    -- ** Targets
+    getTargets, Target(..), documentTarget,
     -- ** Progress reporting
     Progress(..), progressSimple, progressDisplay, progressTitlebar, progressProgram, getProgress,
     -- ** Verbosity
@@ -81,11 +83,15 @@ module Development.Shake(
     withTempFile, withTempDir,
     withTempFileWithin, withTempDirWithin,
     -- * File rules
-    need, want, (%>), (|%>), (?>), phony, (~>), phonys,
+    need, want, (%>), (|%>), (?>), phony, phonyWithDocs, phonys,
     (&%>), (&?>),
     orderOnly, orderOnlyAction,
     FilePattern, (?==), (<//>), filePattern,
     needed, trackRead, trackWrite, trackAllow,
+    -- * Aliases
+    (~>), build, buildAny, buildAll,
+    -- * Documented rules
+    buildWithDocs, buildAnyWithDocs, buildAllWithDocs,
     -- * Directory rules
     doesFileExist, doesDirectoryExist, getDirectoryContents, getDirectoryFiles, getDirectoryDirs,
     getDirectoryFilesIO,

--- a/src/Development/Shake/Internal/Core/Rules.hs
+++ b/src/Development/Shake/Internal/Core/Rules.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE RecordWildCards, ScopedTypeVariables #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving, ConstraintKinds #-}
 {-# LANGUAGE ExistentialQuantification, RankNTypes #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies, DeriveDataTypeable #-}
 
 module Development.Shake.Internal.Core.Rules(
-    Rules, runRules,
+    Rules, runRules, getTargets, Target(..),
     RuleResult, addBuiltinRule, addBuiltinRuleEx,
     noLint, noIdentity,
     getShakeOptionsRules,
     getUserRuleInternal, getUserRuleOne, getUserRuleList, getUserRuleMaybe,
-    addUserRule, alternatives, priority, versioned,
+    addUserRule, documentTarget, alternatives, priority, versioned,
     action, withoutActions
     ) where
 
@@ -23,7 +23,7 @@ import Control.Monad.Trans.Reader
 import Development.Shake.Classes
 import General.Binary
 import General.Extra
-import Data.Typeable.Extra
+import Data.Data
 import Data.Function
 import Data.List.Extra
 import qualified Data.HashMap.Strict as Map
@@ -125,25 +125,61 @@ modifyRules f (Rules r) = Rules $ do
         modifyIORef' refOld (<> f rules)
         return res
 
-runRules :: ShakeOptions -> Rules () -> IO ([(Stack, Action ())], Map.HashMap TypeRep BuiltinRule, TMap.Map UserRuleVersioned)
+runRules :: ShakeOptions -> Rules () -> IO ([(Stack, Action ())], Map.HashMap TypeRep BuiltinRule, TMap.Map UserRuleVersioned, [Target])
 runRules opts (Rules r) = do
     ref <- newIORef mempty
     runReaderT r (opts, ref)
     SRules{..} <- readIORef ref
-    return (runListBuilder actions, builtinRules, userRules)
+    return (runListBuilder actions, builtinRules, userRules, runListBuilder targets)
+
+-- | Get all the targets explicitly registered in the given rules. The names in
+-- 'phony' and '~>' as well as the file patterns in '%>', '|%>' and '&%>' are
+-- registered as targets.
+--
+-- One application for retrieving the targets from the rules is for implementing
+-- a shell autocomplete feature. To implement autocompletion most shells require
+-- the program to output the list of arguments it supports. In this case we want
+-- to output "someTarget" and "someFile" when the program is invoked with the
+-- "autocomplete" command.
+--
+-- @
+-- main = do
+--   let rules = do
+--         phony "someTarget" $ pure ()
+--         "someFile" %> \\_ -> pure ()
+--   shakeArgsWith shakeOptions [] $ \\_flags targets ->
+--     case targets of
+--       "autocomplete" : _args -> do
+--          targets <- getTargets shakeOptions rules
+--          forM_ targets $ \\t ->
+--            putStrLn $ target t ++
+--              maybe "" (\\doc -> ":" ++ doc) (documentation t)
+--          pure Nothing
+--       target : _args -> pure $ Just $ want [ target ] >> rules
+-- @
+getTargets :: ShakeOptions -> Rules () -> IO [Target]
+getTargets opts rs = do
+  (_actions, _ruleinfo, _userRules, targets) <- runRules opts rs
+  return targets
+
+data Target = Target
+    {target :: !String
+    ,documentation :: !(Maybe String)
+    } deriving (Eq,Ord,Show,Read,Data,Typeable)
 
 data SRules = SRules
     {actions :: !(ListBuilder (Stack, Action ()))
     ,builtinRules :: !(Map.HashMap TypeRep{-k-} BuiltinRule)
     ,userRules :: !(TMap.Map UserRuleVersioned)
+    ,targets :: !(ListBuilder Target)
     }
 
 instance Semigroup SRules where
-    (SRules x1 x2 x3) <> (SRules y1 y2 y3) = SRules (mappend x1 y1) (Map.unionWithKey f x2 y2) (TMap.unionWith (<>) x3 y3)
+    (SRules x1 x2 x3 x4) <> (SRules y1 y2 y3 y4) = SRules (mappend x1 y1) (Map.unionWithKey f x2 y2) (TMap.unionWith (<>) x3 y3) (mappend x4 y4)
         where f k a b = throwImpure $ errorRuleDefinedMultipleTimes k [builtinLocation a, builtinLocation b]
 
 instance Monoid SRules where
-    mempty = SRules mempty Map.empty TMap.empty
+    mempty = SRules mempty Map.empty TMap.empty mempty
     mappend = (<>)
 
 instance Semigroup a => Semigroup (Rules a) where
@@ -158,6 +194,15 @@ instance (Semigroup a, Monoid a) => Monoid (Rules a) where
 --   The user rules can be retrieved by 'getUserRuleList'.
 addUserRule :: Typeable a => a -> Rules ()
 addUserRule r = newRules mempty{userRules = TMap.singleton $ UserRuleVersioned False $ UserRule r}
+
+-- | Register a 'Target' with some optional documentation.
+--
+-- The registered targets in a @Rules@ can be retrieved using 'getTargets'.
+documentTarget
+    :: String -- ^ Target name or file pattern
+    -> Maybe String -- ^ Optional documentation that describes this target
+    -> Rules ()
+documentTarget t mbDoc = newRules mempty{targets = newListBuilder $ Target t mbDoc}
 
 -- | A suitable 'BuiltinLint' that always succeeds.
 noLint :: BuiltinLint key value

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -72,7 +72,7 @@ data RunState = RunState
 open :: Cleanup -> ShakeOptions -> Rules () -> IO RunState
 open cleanup opts rs = withInit opts $ \opts@ShakeOptions{..} diagnostic _ -> do
     diagnostic $ return "Starting run"
-    (actions, ruleinfo, userRules) <- runRules opts rs
+    (actions, ruleinfo, userRules, _targets) <- runRules opts rs
     checkShakeExtra shakeExtra
     curdir <- getCurrentDirectory
 

--- a/src/Development/Shake/Internal/Rules/File.hs
+++ b/src/Development/Shake/Internal/Rules/File.hs
@@ -5,8 +5,12 @@ module Development.Shake.Internal.Rules.File(
     need, needHasChanged, needBS, needed, neededBS, want,
     trackRead, trackWrite, trackAllow,
     defaultRuleFile,
-    (%>), (|%>), (?>), phony, (~>), phonys,
+    (%>), (|%>), (?>), phony, phonyWithDocs, phonys,
     resultHasChanged,
+    -- * Aliases
+    (~>), build, buildAny,
+    -- * Documented rules
+    buildWithDocs, buildAnyWithDocs,
     -- * Internal only
     FileQ(..), FileA(..), fileStoredValue, fileEqualValue, EqualCost(..), fileForward
     ) where
@@ -494,22 +498,44 @@ root help test act = addUserRule $ FileRule help $ \x -> if not $ test x then No
 --   Use a phony rule!  For file-producing rules which should be
 --   rerun every execution of Shake, see 'Development.Shake.alwaysRerun'.
 phony :: Located => String -> Action () -> Rules ()
-phony oname@(toStandard -> name) act =
-    addPhony ("phony " ++ show oname ++ " at " ++ callStackTop) $ \s -> if s == name then Just act else Nothing
+phony name act = phony' phonyDoc "phony" callStackTop name act
+
+-- | Infix operator alias for 'phony', for sake of consistency with normal
+--   rules.
+(~>) :: Located => String -> Action () -> Rules ()
+(~>) name act = phony' phonyDoc "~>" callStackTop name act
+
+phonyDoc :: String
+phonyDoc = "A phony target"
+
+-- | Like 'phony' but allows overriding the default documentation of the target.
+phonyWithDocs
+    :: Located
+    => String -- ^ Documentation that describes the target
+    -> String -- ^ Name of the target
+    -> Action ()
+    -> Rules ()
+phonyWithDocs doc name act = phony' doc "phonyWithDocs" callStackTop name act
+
+phony'
+    :: Located
+    => String -- ^ Documentation
+    -> String -- ^ Operator name
+    -> String -- ^ CallStack
+    -> String -- ^ Target name
+    -> Action ()
+    -> Rules ()
+phony' doc opName stack oname@(toStandard -> name) act = do
+    documentTarget name (Just doc)
+    addPhony (opName ++ show oname ++ " at " ++ stack) $ \s ->
+      if s == name then Just act else Nothing
 
 -- | A predicate version of 'phony', return 'Just' with the 'Action' for the matching rules.
 phonys :: Located => (String -> Maybe (Action ())) -> Rules ()
 phonys = addPhony ("phonys at " ++ callStackTop)
 
--- | Infix operator alias for 'phony', for sake of consistency with normal
---   rules.
-(~>) :: Located => String -> Action () -> Rules ()
-(~>) oname@(toStandard -> name) act =
-    addPhony (show oname ++ " ~> at " ++ callStackTop) $ \s -> if s == name then Just act else Nothing
-
 addPhony :: String -> (String -> Maybe (Action ())) -> Rules ()
 addPhony help act = addUserRule $ FileRule help $ fmap ModePhony . act
-
 
 -- | Define a rule to build files. If the first argument returns 'True' for a given file,
 --   the second argument will be used to build it. Usually '%>' is sufficient, but '?>' gives
@@ -527,11 +553,38 @@ addPhony help act = addUserRule $ FileRule help $ fmap ModePhony . act
 (?>) :: Located => (FilePath -> Bool) -> (FilePath -> Action ()) -> Rules ()
 (?>) test act = priority 0.5 $ root ("?> at " ++ callStackTop) test act
 
-
 -- | Define a set of patterns, and if any of them match, run the associated rule. Defined in terms of '%>'.
 --   Think of it as the OR (@||@) equivalent of '%>'.
 (|%>) :: Located => [FilePattern] -> (FilePath -> Action ()) -> Rules ()
-(|%>) pats act = do
+(|%>) pats act =
+    withFrozenCallStack $
+      buildAny' Nothing (" |%> at " ++ callStackTop) pats act
+
+-- | Function alias for '|%>'.
+buildAny ::  Located => [FilePattern] -> (FilePath -> Action ()) -> Rules ()
+buildAny pats act =
+    withFrozenCallStack $
+      buildAny' Nothing (" buildAny at " ++ callStackTop) pats act
+
+-- | Like 'buildAny' or '|%>' but associates the given documentation with the target.
+buildAnyWithDocs
+    :: Located
+    => String -- ^ Documentation that describes the target
+    -> [FilePattern]
+    -> (FilePath -> Action ())
+    -> Rules ()
+buildAnyWithDocs doc pats act =
+    withFrozenCallStack $
+      buildAny' (Just doc) (" buildAnyWithDocs at " ++ callStackTop) pats act
+
+buildAny'
+    :: Maybe String
+    -> String
+    -> [FilePattern]
+    -> (FilePath -> Action ())
+    -> Rules ()
+buildAny' mbDoc msg pats act = do
+    forM_ pats $ \pat -> documentTarget pat mbDoc
     let (simp,other) = partition simple pats
     case map toStandard simp of
         [] -> return ()
@@ -539,7 +592,7 @@ addPhony help act = addUserRule $ FileRule help $ fmap ModePhony . act
         ps -> let set = Set.fromList ps in root help (flip Set.member set . toStandard) act
     unless (null other) $
         let ps = map (?==) other in priority 0.5 $ root help (\x -> any ($ x) ps) act
-    where help = show pats ++ " |%> at " ++ callStackTop
+    where help = show pats ++ msg
 
 -- | Define a rule that matches a 'FilePattern', see '?==' for the pattern rules.
 --   Patterns with no wildcards have higher priority than those with wildcards, and no file
@@ -563,4 +616,29 @@ addPhony help act = addUserRule $ FileRule help $ fmap ModePhony . act
 --   If the 'Action' completes successfully the file is considered up-to-date, even if the file
 --   has not changed.
 (%>) :: Located => FilePattern -> (FilePath -> Action ()) -> Rules ()
-(%>) test act = withFrozenCallStack $ (if simple test then id else priority 0.5) $ root (show test ++ " %> at " ++ callStackTop) (test ?==) act
+(%>) test act = withFrozenCallStack $ build' Nothing (" %> at " ++ callStackTop) test act
+
+-- | Function alias for '%>'.
+build :: Located => FilePattern -> (FilePath -> Action ()) -> Rules ()
+build test act = withFrozenCallStack $ build' Nothing (" build at " ++ callStackTop) test act
+
+-- | Like 'build' or '%>' but associates the given documentation with the target.
+buildWithDocs
+    :: Located
+    => String -- ^ Documentation that describes the target
+    -> FilePattern
+    -> (FilePath -> Action ())
+    -> Rules ()
+buildWithDocs doc test act =
+    withFrozenCallStack $ build' (Just doc) (" buildWithDocs at " ++ callStackTop) test act
+
+build'
+    :: Maybe String
+    -> String
+    -> FilePattern
+    -> (FilePath -> Action ())
+    -> Rules ()
+build' mbDoc msg test act = do
+  documentTarget test mbDoc
+  (if simple test then id else priority 0.5) $
+    root (show test ++ msg) (test ?==) act

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -34,6 +34,7 @@ import qualified Test.FilePath
 import qualified Test.FilePattern
 import qualified Test.Files
 import qualified Test.Forward
+import qualified Test.GetTargets
 import qualified Test.History
 import qualified Test.Journal
 import qualified Test.Lint
@@ -88,6 +89,7 @@ mains =
     ,"filepattern" * Test.FilePattern.main
     ,"files" * Test.Files.main
     ,"forward" * Test.Forward.main
+    ,"gettargets" * Test.GetTargets.main
     ,"history" * Test.History.main
     ,"journal" * Test.Journal.main
     ,"lint" * Test.Lint.main

--- a/src/Test/GetTargets.hs
+++ b/src/Test/GetTargets.hs
@@ -1,0 +1,63 @@
+module Test.GetTargets(main) where
+
+import Development.Shake
+import Test.Type
+
+main :: IO () -> IO ()
+main _sleeper = do
+    targets <- getTargets shakeOptions rules
+    targets === expected
+
+rules :: Rules ()
+rules = do
+  phony "phony1" $ return ()
+
+  "file1" %> \_ -> return ()
+  ["file2", "file3"] |%> \_ -> return ()
+  ["file4", "file5"] &%> \_ -> return ()
+
+  build "file6" $ \_ -> return ()
+  buildAny ["file7", "file8"] $ \_ -> return ()
+  buildAll ["file9", "file10"] $ \_ -> return ()
+
+  phonyWithDocs
+    "Builds something really good"
+    "phony2" $ return ()
+
+  buildWithDocs
+    "a great file"
+    "file11" $ \_ -> return ()
+
+  buildAnyWithDocs
+    "awesome files"
+    ["file12", "file13"] $ \_ -> return ()
+
+  buildAllWithDocs
+    "just briliant"
+    ["file14", "file15"] $ \_ -> return ()
+
+expected :: [Target]
+expected =
+    [ Target "phony1" (Just "A phony target")
+
+    , Target "file1"  Nothing
+    , Target "file2"  Nothing
+    , Target "file3"  Nothing
+    , Target "file4"  Nothing
+    , Target "file5"  Nothing
+
+    , Target "file6"  Nothing
+    , Target "file7"  Nothing
+    , Target "file8"  Nothing
+    , Target "file9"  Nothing
+    , Target "file10" Nothing
+
+    , Target "phony2" (Just "Builds something really good")
+
+    , Target "file11" (Just "a great file")
+    , Target "file12" (Just "awesome files")
+    , Target "file13" (Just "awesome files")
+    , Target "file14" (Just "just briliant")
+    , Target "file15" (Just "just briliant")
+
+    ]


### PR DESCRIPTION
Hi Neil, as promised I added:

```haskell
getTargets :: ShakeOptions -> Rules () -> IO [String]
```

`getTargets` returns the targets that are registered by `phony`, `~>`,   `%>`, `|%>`  and `&%>`.

As discussed, this is useful for implementing shell autocompletion of targets for example.

Future work
-----------------
A future extension could be to add a combinator that can associate some documentation with a Rule. Then we can imagine a function:

```haskell
getTargetsWithDocs :: ShakeOptions -> Rules () -> IO [(String, Maybe String)]
``` 

which is like `getTargets` but pairs the targets with some optional documentation. This documentation can then be used in shell autocompletion for example for shells that support that.

The combinator to add documentation could look like:

```haskell
doc :: String -> Rules () -> Rules ()
```

The semantics is that `doc txt r` will associate `txt` with every target in `r`. Inner calls of `doc` will overwrite outer calls. So `doc txt1 (doc txt2 r)` will associate `txt2` with every target in `r`.

I'm not sure this is the right API yet. It needs more thought and experimentation.
