### PR TITLE
WIP Democratize shared cache implementations

### DIFF
--- a/src/Development/Shake/Internal/History/Shared/Api.hs
+++ b/src/Development/Shake/Internal/History/Shared/Api.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE RankNTypes      #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections   #-}
+{-# OPTIONS -Wall #-}
+
+module Development.Shake.Internal.History.Shared.Api
+  ( SharedCache(..)
+  , SharedFileSystem(..)
+  ) where
+
+import qualified Data.ByteString                          as BS
+import           Data.Maybe
+import           Development.Shake.Classes
+import           Development.Shake.Internal.FileInfo
+import           Development.Shake.Internal.History.Types
+import           Development.Shake.Internal.Value
+import           General.Binary
+import           General.Extra
+import           General.Wait
+import           Prelude
+
+data SharedCache shared = SharedCache
+    { addShared :: shared -> Key -> Ver -> Ver -> [[(Key, BS_Identity)]] -> BS_Store -> [FilePath] -> IO ()
+    , lookupShared :: (Eq shared, Storable shared) =>
+                          shared -> (Key -> Wait Locked (Maybe BS_Identity)) -> Key -> Ver -> Ver -> Wait Locked (Maybe (BS_Store, [[Key]], IO ()))
+    , removeShared :: shared -> (Key -> Bool) -> IO ()
+    , listShared :: shared -> IO ()
+    }
+
+-- | An abstraction for shared cache filesystems.
+data SharedFileSystem shared = SharedFileSystem
+  {
+    loadSharedEntry :: shared -> Key -> IO [BS.ByteString]
+  , saveSharedEntry :: shared -> Key -> [(FilePath, FileHash)] -> Builder -> IO ()
+  -- | Remove keys for which the predicate returns False
+  , updateSharedKeys :: shared -> (Key -> IO Bool) -> IO ()
+  }

--- a/src/Development/Shake/Internal/Options.hs
+++ b/src/Development/Shake/Internal/Options.hs
@@ -17,6 +17,7 @@ import Control.Monad
 import General.Extra
 import qualified Data.HashMap.Strict as Map
 import Development.Shake.Internal.FilePattern
+import Development.Shake.Internal.History.Shared
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.UTF8 as UTF8
 import Development.Shake.Internal.CmdOption
@@ -203,7 +204,7 @@ data ShakeOptions = ShakeOptions
         -- ^ Defaults to 'False'. Ignore any differences in 'shakeVersion'.
     ,shakeColor :: Bool
         -- ^ Defaults to 'False'. Whether to colorize the output.
-    ,shakeShare :: Maybe FilePath
+    ,shakeShare :: Maybe (SharedCache Shared)
         -- ^ Defaults to 'Nothing'. Whether to use and store outputs in a shared directory.
     ,shakeCloud :: [String]
         -- ^ Defaults to @[]@. Cloud servers to talk to forming a shared cache.


### PR DESCRIPTION
This change defines two datatypes `SharedCache` (internal) and `SharedFileSystem` (api) that allow users of Shake to define their own stores of cache history data.

This is only a draft, as I was unsure of whether it would be accepted and didn't want to invest too much time into it. Also the manual `Data` instances really threw me off :)