### PR TITLE
Store traces in a tree form rather than a list so span can be calcula…

### DIFF
--- a/src/Development/Shake/Internal/Core/Action.hs
+++ b/src/Development/Shake/Internal/Core/Action.hs
@@ -243,9 +243,21 @@ traced msg act = do
     stop <- liftIO globalTimestamp
     let trace = newTrace msg start stop
     liftIO $ evaluate $ rnf trace
-    Action $ modifyRW $ \s -> s{localTraces = trace : localTraces s}
+    Action $ modifyRW $ \s -> s{localTraces = mergeTraceTForest trace $ localTraces s}
     return res
 
+mergeTraceTForest :: Trace -> TForest -> TForest
+mergeTraceTForest t tf =
+  let f (TTree d cs) t2 = TTree d $ if null cs then
+                                      [t2] else
+                                      map (\t3 -> f t3 t2) cs
+      f (TLeaf d) t2 = TTree d [t2]
+      n = TLeaf t
+      roots = tRoots tf in
+    TForest { tRoots = if null roots
+                       then [n]
+                       else map (\t2 -> f t2 n) roots
+            , tracesList = t:(tracesList tf) }
 
 ---------------------------------------------------------------------
 -- TRACKING

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -212,7 +212,7 @@ runKey global@Global{globalOptions=ShakeOptions{..},..} stack k r mode continue 
                         ,built = globalStep
                         ,depends = nubDepends $ reverse localDepends
                         ,execution = doubleToFloat $ dur - localDiscount
-                        ,traces = reverse localTraces}
+                        ,traces = localTraces}
             where
                 mkResult value store = (value, if globalOneShot then BS.empty else store)
 

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -337,7 +337,7 @@ incrementStep db = runLocked db $ do
     return step
 
 toStepResult :: Step -> Result (Value, BS_Store)
-toStepResult i = Result (newValue i, runBuilder $ putEx i) i i [] 0 []
+toStepResult i = Result (newValue i, runBuilder $ putEx i) i i [] 0 $ TForest [] []
 
 fromStepResult :: Result BS_Store -> Step
 fromStepResult = getEx . result
@@ -353,9 +353,22 @@ recordRoot step locals (doubleToFloat -> end) db = runLocked db $ do
             ,built = step
             ,depends = nubDepends $ reverse $ localDepends local
             ,execution = 0
-            ,traces = reverse $ Trace BS.empty end end : localTraces local}
+            ,traces = mergeTraceTForest (Trace BS.empty end end) (localTraces local)}
     setMem db rootId rootKey $ Ready rootRes
     liftIO $ setDisk db rootId rootKey $ Loaded $ fmap snd rootRes
+
+mergeTraceTForest :: Trace -> TForest -> TForest
+mergeTraceTForest t tf =
+  let f (TTree d cs) t2 = TTree d $ if null cs then
+                                      [t2] else
+                                      map (\t3 -> f t3 t2) cs
+      f (TLeaf d) t2 = TTree d [t2]
+      n = TLeaf t
+      roots = tRoots tf in
+    TForest { tRoots = if null roots
+                       then [n]
+                       else map (\t2 -> f t2 n) roots
+            , tracesList = t:(tracesList tf) }
 
 
 loadSharedCloud :: DatabasePoly k v -> ShakeOptions -> Map.HashMap TypeRep BuiltinRule -> IO (Maybe Shared, Maybe Cloud)


### PR DESCRIPTION
I added the  TTree, TForest, PtTree, PtForest data types to maintain the ordering and relationship of the traced commands to accurately calculate span.  The original list is also maintained, although maybe calculating it when necessary is better.  

Additionally to calculating span I think this could be useful for future build system analysis.

I look forward to your comment on if you think this is worthwhile or if there is a better way to implement it.

