### PR TITLE
Fix serious bug in writeFile'

### DIFF
--- a/src/Development/Shake/Internal/Derived.hs
+++ b/src/Development/Shake/Internal/Derived.hs
@@ -121,7 +121,7 @@ readFile' x = need [x] >> liftIO (readFile x)
 writeFile' :: (MonadIO m, Partial) => FilePath -> String -> m ()
 writeFile' name x = liftIO $ do
     createDirectoryRecursive $ takeDirectory name
-    removeFile_ x -- symlink safety
+    removeFile_ name -- symlink safety
     writeFile name x
 
 


### PR DESCRIPTION
This mistake caused a file to be deleted if it had the same name
as the contents of the file you wanted to write.

