### PR TITLE
RFC: UI fixes for --compact mode

### DIFF
--- a/shake.cabal
+++ b/shake.cabal
@@ -111,7 +111,7 @@ library
 
     if flag(cloud)
         cpp-options: -DNETWORK
-        build-depends: network, network-uri
+        build-depends: network, network-uri, HTTP
 
     if impl(ghc < 8.0)
         build-depends: semigroups >= 0.18
@@ -231,7 +231,7 @@ executable shake
 
     if flag(cloud)
         cpp-options: -DNETWORK
-        build-depends: network, network-uri
+        build-depends: network, network-uri, HTTP
 
     if impl(ghc < 8.0)
         build-depends: semigroups >= 0.18
@@ -349,7 +349,7 @@ test-suite shake-test
 
     if flag(cloud)
         cpp-options: -DNETWORK
-        build-depends: network, network-uri
+        build-depends: network, network-uri, HTTP
 
     if impl(ghc < 8.0)
         build-depends: semigroups >= 0.18

--- a/shake.cabal
+++ b/shake.cabal
@@ -170,6 +170,7 @@ library
         Development.Shake.Internal.Rules.Oracle
         Development.Shake.Internal.Rules.OrderOnly
         Development.Shake.Internal.Rules.Rerun
+        Development.Shake.Internal.TermSize
         Development.Shake.Internal.Value
         General.Bilist
         General.Binary
@@ -285,6 +286,7 @@ executable shake
         Development.Shake.Internal.Rules.Oracle
         Development.Shake.Internal.Rules.OrderOnly
         Development.Shake.Internal.Rules.Rerun
+        Development.Shake.Internal.TermSize
         Development.Shake.Internal.Value
         General.Bilist
         General.Binary
@@ -405,6 +407,7 @@ test-suite shake-test
         Development.Shake.Internal.Rules.Oracle
         Development.Shake.Internal.Rules.OrderOnly
         Development.Shake.Internal.Rules.Rerun
+        Development.Shake.Internal.TermSize
         Development.Shake.Internal.Value
         Development.Shake.Rule
         Development.Shake.Util

--- a/src/Development/Shake/Internal/TermSize.hsc
+++ b/src/Development/Shake/Internal/TermSize.hsc
@@ -1,0 +1,48 @@
+
+-- | Get terminal size with @ioctl@
+module Development.Shake.Internal.TermSize (
+    getTermSize
+    ) where
+
+#ifdef WIN32
+getTermSize :: IO (Int, Int)
+getTermSize = return (25,80)
+#else
+
+import Foreign
+import Foreign.C.Error
+import Foreign.C.Types
+
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+-- Trick for calculating alignment of a type, taken from
+-- http://www.haskell.org/haskellwiki/FFICookBook#Working_with_structs
+#let our_alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)
+
+-- The ws_xpixel and ws_ypixel fields are unused, so I've omitted them here.
+data WinSize = WinSize { wsRow, wsCol :: CUShort }
+
+instance Storable WinSize where
+  sizeOf _ = (#size struct winsize)
+  alignment _ = (#our_alignment struct winsize)
+  peek ptr = do
+    row <- (#peek struct winsize, ws_row) ptr
+    col <- (#peek struct winsize, ws_col) ptr
+    return $ WinSize row col
+  poke ptr (WinSize row col) = do
+    (#poke struct winsize, ws_row) ptr row
+    (#poke struct winsize, ws_col) ptr col
+
+foreign import ccall "sys/ioctl.h ioctl"
+  ioctl :: CInt -> CInt -> Ptr WinSize -> IO CInt
+
+-- | Return current number of (rows, columns) of the terminal.
+getTermSize :: IO (Int, Int)
+getTermSize =
+  with (WinSize 0 0) $ \ws -> do
+    throwErrnoIfMinus1 "ioctl" $
+      ioctl (#const STDOUT_FILENO) (#const TIOCGWINSZ) ws
+    WinSize row col <- peek ws
+    return (fromIntegral row, fromIntegral col)
+#endif

--- a/src/General/EscCodes.hs
+++ b/src/General/EscCodes.hs
@@ -9,6 +9,7 @@ module General.EscCodes(
     escCursorUp,
     escClearLine,
     escForeground,
+    escBold,
     escNormal
     ) where
 
@@ -88,6 +89,8 @@ escCursorUp i = "\ESC[" ++ show i ++ "A"
 escClearLine :: String
 escClearLine = "\ESC[K"
 
+escBold :: String
+escBold = "\ESC[1m"
 
 data Color = Black | Red | Green | Yellow | Blue | Magenta | Cyan | White
     deriving (Show,Enum)


### PR DESCRIPTION
This introduces a number of fixes for the `--compact` UX, making it much nicer on the eyes and more usable, IMO.

Notably, it:

  1) Ensures all traces outputted to the terminal are truncated to the terminal width. This avoids edge cases where a line is too long and wraps onto the next line in your terminal, which causes the remainder of the UX to become offset badly. (In our build system we have one traced command that prints a 200+ character-long string, which screws up the build formatting). Note: ninja also does this for the same reasons, and we use the same truncation logic (look up `ElideMiddle` in (util.cc)[https://github.com/ninja-build/ninja/blob/1bcc689324bdee090eed035353724abc3fa7c909/src/util.cc#L596]). **NOTE**: in order to do this, we must introduce an `TermSize.hsc` module to call `ioctl(STDOUT_FILENO, TIOCGWINSZ, ...)` on Unix. A normal FFI import will not work, because we must be aware of the structure that the `ioctl` fills; it does not simply return integer values. The `.hsc` file means `hsc2hs` must be available now.

  2) Clears and resets the cursor position for the line back to the original position it was in when you invoked `shake`, an also clears all lines it printed on. This effectively restores the terminal back to the state it was when you ran `shake`. It also does not output anything on no-op builds, either.

  3) No more empty job lines: the UX expands dynamically based on whether or not a running thread is executing a job. By simply moving the line type to `Maybe String` and using `mapMaybes`, we get the benefit that empty lines with no jobs scheduled (e.g. because you are in a critical path, or because the build is about to end) are not printed. As noted, this is dynamically calculated, so this also has the nice side effect that e.g. if you have 4 threads running and the 3rd one in the UI list is finished, the 4th entry will "collapse" into the 3rd one on the next refresh, never showing an empty line.

  4) It colorizes the output a little differently now, including bolding commands that are executing for a rule (e.g. in the compact output `* foo/bar/baz.o (cc 25s)`, `cc` will now be bolded and colorized red/yellow appropriately as well.)

  5) It refactors the `progressDisplay` function into an internal helper which is now also used by `compactUI`. This is necessary so that we can change the output in the compact UX more liberally in the future. Note: `progressRaw` may actually be useful to the user as an exposed API (after some cleanups/renaming), but for now it is hidden. Note that I use `formatMessage` etc which is also internal, hence why I left some of the code paths the same.

---

Our cmake/ninja build at `$WORK` effectively ran into all of these cases when using the `shake` executable in compact mode: ultra long column rule names, long paths that take 20+ seconds to build (invoking red/yellow status lines for the rules), and a job pool that shrinks entries as the build winds down and almost finishes. The extra stuff was just to make it all look a bit nicer.

---

Please do not merge this just yet. There are still some tweaks I need to make (in particular the `ioctl` stuff should be attributed to the place I got it from), and possibly tweaking the coloring/output formatting to be nicer. And there are some questions about how things should be structured. However, I have private build that I am using with these changes, for `$WORK`, and I have been successfully using them for the past day. I think the results are effectively much nicer.

In particular, the introduction of an `.hsc` file may mean that the Shake library can no longer trivially be loaded with just a `ghci` command, which could be seen as a major downside. I did not experience this, since I just use `cabal new-repl`, but it is worth nothing since I think you use this workflow a lot, Neil. I can see two alternatives:

  1) Move this code into a separate package, so `shake` itself needs no `.hsc` files directly. This would also mean we could possibly, eventually add support for Windows too, independently of Shake.

  2) Move this code into a `.c` file. This is easier but still suffers from the same `ghci` drawback, since you'll have to `foreign import` it and the object file may not be compiled.

---

However, at least 5d8d0e509e489dbcf3a560b82c7be180379d937a seems uncontroversial and an obvious fix. This fixes using `cabal new-repl` to load shake. You may just want to cherry pick that one change immediately right now. I can rebase the actual majority of the changes onto `master` again later.