### PR TITLE
Add addHelpSuffix, for extra --help info

### DIFF
--- a/src/Development/Shake.hs
+++ b/src/Development/Shake.hs
@@ -61,7 +61,7 @@ module Development.Shake(
     getShakeOptions, getShakeOptionsRules, getHashedShakeVersion,
     getShakeExtra, getShakeExtraRules, addShakeExtra,
     -- ** Command line
-    shakeArgs, shakeArgsWith, shakeArgsOptionsWith, shakeOptDescrs,
+    shakeArgs, shakeArgsWith, shakeArgsOptionsWith, shakeOptDescrs, addHelpSuffix,
     -- ** Targets
     getTargets, addTarget, withTargetDocs, withoutTargets,
     -- ** Progress reporting

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -73,7 +73,7 @@ data RunState = RunState
 open :: Cleanup -> ShakeOptions -> Rules () -> IO RunState
 open cleanup opts rs = withInit opts $ \opts@ShakeOptions{..} diagnostic _ -> do
     diagnostic $ return "Starting run"
-    (actions, ruleinfo, userRules, _targets) <- runRules opts rs
+    RulesInfo{riActions = actions, riBuiltinRules = ruleinfo, riUserRules = userRules} <- runRules opts rs
 
     diagnostic $ return $ "Number of actions = " ++ show (length actions)
     diagnostic $ return $ "Number of builtin rules = " ++ show (Map.size ruleinfo) ++ " " ++ show (Map.keys ruleinfo)

--- a/src/Test/Targets.hs
+++ b/src/Test/Targets.hs
@@ -1,12 +1,15 @@
 module Test.Targets(main) where
 
 import Development.Shake
+import Development.Shake.Internal.Core.Rules (getHelpSuffix)
 import Test.Type
 
 main :: IO () -> IO ()
 main _sleeper = do
     targets <- getTargets shakeOptions rules
     targets === expected
+    helpSuffix <- getHelpSuffix shakeOptions rules
+    helpSuffix === ["Don't Panic", "Know where your towel is"]
 
 rules :: Rules ()
 rules = do
@@ -26,6 +29,9 @@ rules = do
         withTargetDocs "awesome files" $ ["file12", "file13"] &%> \_ -> return ()
         phony "Foo" $ return ()
         withoutTargets $ phony "Bar" $ return ()
+
+    addHelpSuffix "Don't Panic"
+    addHelpSuffix "Know where your towel is"
 
 
 expected :: [(String, Maybe String)]


### PR DESCRIPTION
Fixes #689

This is a lot less polished then I would have preferred, but it took me long enough just to get to this point, with a manual test to verify it works.  Please feel free to point out the silliest of mistakes, as I'm still ramping up in Haskell and there's lots I'm unfamiliar with still.  And advice or guidance is very welcome.

Should I copy `Test.Targets` and build a test that setups up rules with `addHelpSuffix` and test it with `getHelpSuffix`?  Or should I look to be more ambitiuous and create a test for the whole of the `--help` behaviour?