### PR TITLE
Print rebuild warnings in yellow & errors in red

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Changelog for Shake (* = breaking change)
 
+    #703, print rebuild warnings in yellow and errors in red
     #706, rename Verbosity's constructors and add Warn
     #443, add getEnvError
     #662, add Partial to command/cmd

--- a/src/Development/Shake/Internal/Args.hs
+++ b/src/Development/Shake/Internal/Args.hs
@@ -294,7 +294,12 @@ escape :: Color -> String -> String
 escape color x = escForeground color ++ x ++ escNormal
 
 outputColor :: (Verbosity -> String -> IO ()) -> Verbosity -> String -> IO ()
-outputColor output v msg = output v $ escape Blue msg
+outputColor output v msg = output v $ color msg
+  where color = case v of
+            Silent -> id
+            Error  -> escape Red
+            Warn   -> escape Yellow
+            _      -> escape Blue
 
 -- | True if it has a potential effect on ShakeOptions
 shakeOptsEx :: [(Bool, OptDescr (Either String ([Extra], ShakeOptions -> ShakeOptions)))]

--- a/src/Development/Shake/Internal/Core/Storage.hs
+++ b/src/Development/Shake/Internal/Core/Storage.hs
@@ -196,7 +196,7 @@ usingStorage cleanup ShakeOptions{..} diagnostic witness = do
             t <- getCurrentTime
             appendFile (shakeFiles </> ".shake.storage.log") $ "\n[" ++ show t ++ "]: " ++ trimEnd x ++ "\n"
         outputErr x = do
-            when (shakeVerbosity >= Error) $ shakeOutput Error $ unlines x
+            when (shakeVerbosity >= Warn) $ shakeOutput Warn $ unlines x
             unexpected $ unlines x
 
 


### PR DESCRIPTION
Builds on #706
Fixes #640

---
Original description:

I'm submitting this for early feedback.  (https://42floors.com/blog/startups/thirty-percent-feedback)

This is what it looks like in an out-of-repo, manual test I have:

![image](https://user-images.githubusercontent.com/344610/62518670-f841bc80-b821-11e9-983c-a7de39f932a3.png)

But I suspect that duplicating `shakeOutput` is not a good strategy, so I'm looking for some advice.

If this way is OK, then I'll see to adding a test for it, adding it to the release notes, and adjusting the docs (around its introduction with respects to `shakeOutput`.)