### PR TITLE
Travis CI: Switch to "language: generic"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: minimal
 matrix:
   include:
   - env: GHCVER=7.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+language: generic
 matrix:
   include:
   - env: GHCVER=7.10


### PR DESCRIPTION
Switches awway from the default, which is actually "language: ruby". See
https://docs.travis-ci.com/user/languages/minimal-and-generic/

From some testing this looks like it shaves 4 minutes off the total
build, from 1h51m to 1h47m.  Not amazing, but still net positive.

Also drop the "sudo: required" that now is a no-op.