### PR TITLE
Use Data.Bifunctor.second (hlint)

### DIFF
--- a/src/Development/Shake/Internal/Core/Database.hs
+++ b/src/Development/Shake/Internal/Core/Database.hs
@@ -9,6 +9,7 @@ module Development.Shake.Internal.Core.Database(
     setMem, setDisk, modifyAllMem
     ) where
 
+import Data.Bifunctor
 import Data.IORef.Extra
 import General.Intern(Id, Intern)
 import Development.Shake.Classes
@@ -107,7 +108,7 @@ setMem :: DatabasePoly k v -> Id -> k -> v -> Locked ()
 setMem Database{..} i k v = liftIO $ Ids.insert status i (k,v)
 
 modifyAllMem :: DatabasePoly k v -> (v -> v) -> Locked ()
-modifyAllMem Database{..} f = liftIO $ Ids.forMutate status $ \(k, s) -> (k, f s)
+modifyAllMem Database{..} f = liftIO $ Ids.forMutate status $ second f
 
 setDisk :: DatabasePoly k v -> Id -> k -> v -> IO ()
 setDisk = journal

--- a/website/Main.hs
+++ b/website/Main.hs
@@ -85,7 +85,7 @@ readPage mode code file = do
     return Page{..}
     where
         links (TagOpen linkLevel@['h',i] at:xs) | i `elem` "234" =
-                first ([Link{..} | i /= '4'] ++) $ second (prefix++) $ links rest
+                bimap ([Link{..} | i /= '4'] ++) (prefix++) $ links rest
             where linkTitle = innerText $ takeWhile (/= TagClose linkLevel) xs
                   linkKey = intercalate "-" $ map (map toLower . filter isAlpha) $ words $
                             takeWhile (`notElem` "?.!") $ fromMaybe linkTitle $ stripPrefix "Q: " linkTitle


### PR DESCRIPTION
    ./src/Development/Shake/Internal/Core/Database.hs:110:63: Suggestion: Use second
    Found:
      \ (k, s) -> (k, f s)
    Perhaps:
      Data.Bifunctor.second f
    Note: increases laziness