### PR TITLE
#722, Add CloseFileHandles and default to not using it

### DIFF
--- a/shake.cabal
+++ b/shake.cabal
@@ -437,6 +437,7 @@ test-suite shake-test
         Test.C
         Test.Cache
         Test.Cleanup
+        Test.CloseFileHandles
         Test.Command
         Test.Config
         Test.Database

--- a/src/Development/Shake/Command.hs
+++ b/src/Development/Shake/Command.hs
@@ -340,6 +340,7 @@ commandExplicitIO params = removeOptionShell params $ \params -> removeOptionFSA
     let optEchoStderr = last $ (not grabStderr && null optFileStderr) : [x | EchoStderr x <- opts]
     let optRealCommand = showCommandForUser2 prog args
     let optUserCommand = last $ optRealCommand : [x | UserCommand x <- opts]
+    let optCloseFds = CloseFileHandles `elem` opts
 
     let bufLBS f = do (a,b) <- buf $ LBS LBS.empty; return (a, (\(LBS x) -> f x) <$> b)
         buf Str{} | optBinary = bufLBS (Str . LBS.unpack)
@@ -366,6 +367,7 @@ commandExplicitIO params = removeOptionShell params $ \params -> removeOptionFSA
         ,poStdout = [DestEcho | optEchoStdout] ++ map DestFile optFileStdout ++ [DestString exceptionBuffer | optWithStdout && not optAsync] ++ concat dStdout
         ,poStderr = [DestEcho | optEchoStderr] ++ map DestFile optFileStderr ++ [DestString exceptionBuffer | optWithStderr && not optAsync] ++ concat dStderr
         ,poAsync = optAsync
+        ,poCloseFds = optCloseFds
         }
     (dur,(pid,exit)) <- duration $ process po
     if exit == ExitSuccess || ResultCode ExitSuccess `elem` results then

--- a/src/Development/Shake/Internal/CmdOption.hs
+++ b/src/Development/Shake/Internal/CmdOption.hs
@@ -28,4 +28,5 @@ data CmdOption
     | AutoDeps -- ^ Compute dependencies automatically.
     | UserCommand String -- ^ The command the user thinks about, before any munging. Defaults to the actual command.
     | FSAOptions String -- ^ Options to @fsatrace@, a list of strings with characters such as @\"r\"@ (reads) @\"w\"@ (writes). Defaults to @\"rwmdqt\"@ if the output of @fsatrace@ is required.
+    | CloseFileHandles -- ^ Before starting the command in the child process, close all file handles except stdin, stdout, stderr in the child process. Uses @close_fds@ from package process and comes with the same caveats, i.e. runtime is linear with the maximum number of open file handles (RLIMIT_NOFILE, see man 2 getrlimit on linux).
       deriving (Eq,Ord,Show,Data,Typeable)

--- a/src/General/Process.hs
+++ b/src/General/Process.hs
@@ -71,6 +71,7 @@ data ProcessOpts = ProcessOpts
     ,poStdout :: [Destination]
     ,poStderr :: [Destination]
     ,poAsync :: Bool
+    ,poCloseFds :: Bool
     }
 
 
@@ -152,7 +153,7 @@ process po = do
     let outFiles = nubOrd [x | DestFile x <- poStdout ++ poStderr]
     let inFiles = nubOrd [x | SrcFile x <- poStdin]
     withFiles WriteMode outFiles $ \outHandle -> withFiles ReadMode inFiles $ \inHandle -> do
-        let cp = (cmdSpec poCommand){cwd = poCwd, env = poEnv, create_group = True, close_fds = True
+        let cp = (cmdSpec poCommand){cwd = poCwd, env = poEnv, create_group = True, close_fds = poCloseFds
                  ,std_in = fst $ stdIn inHandle poStdin
                  ,std_out = stdStream outHandle poStdout poStderr, std_err = stdStream outHandle poStderr poStdout}
         withCreateProcessCompat cp $ \inh outh errh pid ->

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -20,6 +20,7 @@ import qualified Test.Builtin
 import qualified Test.C
 import qualified Test.Cache
 import qualified Test.Cleanup
+import qualified Test.CloseFileHandles
 import qualified Test.Command
 import qualified Test.Config
 import qualified Test.Database
@@ -75,6 +76,7 @@ mains =
     ,"c" * Test.C.main
     ,"cache" * Test.Cache.main
     ,"cleanup" * Test.Cleanup.main
+    ,"closefilehandles" * Test.CloseFileHandles.main
     ,"command" * Test.Command.main
     ,"config" * Test.Config.main
     ,"database" * Test.Database.main

--- a/src/Test/CloseFileHandles.hs
+++ b/src/Test/CloseFileHandles.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE CPP #-}
+module Test.CloseFileHandles(main) where
+
+import Development.Shake
+import Development.Shake.FilePath
+import Test.Type
+import Control.Monad.Extra
+import System.Exit
+import System.IO
+
+#ifdef mingw32_HOST_OS
+
+main = testNone -- don't know how to do this on windows
+
+#else
+
+import System.Posix.IO
+
+main = testBuild test $ do
+    let helper = toNative $ "helper/close_file_handles_helper" <.> exe
+    let name !> test = do want [name]
+                          name ~> do need ["helper/close_file_handles_helper" <.> exe]; test
+
+    let helper_source = unlines
+            ["import System.Environment"
+            ,"import System.Posix.IO"
+            ,"import System.IO"
+            ,"import System.Exit"
+            ,""
+            ,"main = do"
+            ,"  args <- getArgs"
+            ,"  case args of"
+            ,"    [fdString] -> do"
+            ,"       handle <- fdToHandle (read fdString)"
+            ,"       hClose handle"
+            ,"       exitSuccess"
+            ,"    _ -> do"
+            ,"      progName <- getProgName"
+            ,"      hPutStrLn stderr (\"usage: \" ++ progName ++ \" <file descriptor number>\\n    tries closing the file descriptor number\\n    exits successful, if the file descriptor was open\")"
+            ,"      exitWith (ExitFailure 3)"]
+
+    "close_file_handles_helper.hs" %> \out -> do
+        need ["../../src/Test/CloseFileHandles.hs"]
+        writeFileChanged out helper_source
+
+    ["helper/close_file_handles_helper"<.>exe, "close_file_handles_helper.hi", "close_file_handles_helper.o"] &%> \_ -> do
+        need ["close_file_handles_helper.hs"]
+        cmd "ghc --make" "close_file_handles_helper.hs -o helper/close_file_handles_helper"
+
+    let callWithOpenFile cmdWithOpts = withTempFile $
+            \file -> actionBracket (openFile file AppendMode) hClose $
+                \h -> do fd <- liftIO $ handleToFd h
+                         (Exit c, Stdout _, Stderr _) <- cmdWithOpts helper (show fd) :: Action (Exit, Stdout String, Stderr String)
+                         return c
+
+    "defaultbehaviour" !> do
+        c <- callWithOpenFile cmd
+        liftIO $ assertBool (c == ExitSuccess) "handle closed without option CloseFileHandles"
+
+    "closing" !> do
+        c <- callWithOpenFile (cmd CloseFileHandles)
+        liftIO $ assertBool (c /= ExitSuccess) "handle not closed with option CloseFileHandles"
+
+test build = do
+    whenM hasTracker $
+        build ["-j4", "--no-lint"]
+    build ["-j4"]
+
+#endif


### PR DESCRIPTION
On linux closing unrelated file handles isn't the expected/supported
behaviour. The implementation in the used library to this was
slow too, as it iterates over every possible open file descriptor number.

There are two places in the provided test case, where I would be glad for different
suggestions. How can I do a `bracket` like thing in `Action ()`? For the test case
its probably not a problem, but I would love to know.

Also I don't know, how all of that would be tested on windows. Sorry for that.

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
