### PR TITLE
Made CmdArgument an instance of IsCmdArgument

### DIFF
--- a/src/Development/Shake/Command.hs
+++ b/src/Development/Shake/Command.hs
@@ -702,6 +702,7 @@ instance IsCmdArgument String where toCmdArgument = CmdArgument . map Right . wo
 instance IsCmdArgument [String] where toCmdArgument = CmdArgument . map Right
 instance IsCmdArgument CmdOption where toCmdArgument = CmdArgument . return . Left
 instance IsCmdArgument [CmdOption] where toCmdArgument = CmdArgument . map Left
+instance IsCmdArgument CmdArgument where toCmdArgument = id
 instance IsCmdArgument a => IsCmdArgument (Maybe a) where toCmdArgument = maybe mempty toCmdArgument
 
 


### PR DESCRIPTION
It is now possible to include CmdArgument values in `cmd` statements. Fixes #739.
