### PR TITLE
Filter to latest build run in the chrome profiles

### DIFF
--- a/src/Development/Shake/Internal/Profile.hs
+++ b/src/Development/Shake/Internal/Profile.hs
@@ -94,7 +94,6 @@ data ProfileTrace = ProfileTrace
     {prfCommand :: String, prfStart :: Double, prfStop :: Double}
 prfTime ProfileTrace{..} = prfStop - prfStart
 
-
 -- | Generates an report given some build system profiling data.
 writeProfile :: FilePath -> Database -> IO ()
 writeProfile out db = writeProfileInternal out =<< toReport db
@@ -138,9 +137,10 @@ generateHTML xs = do
 
 generateTrace :: [ProfileEntry] -> String
 generateTrace xs = jsonListLines $
-    showEntries 0 [y{prfCommand=prfName x} | x <- xs, y <- prfTraces x] ++
-    showEntries 1 (concatMap prfTraces xs)
+    showEntries 0 [y{prfCommand=prfName x} | x <- onlyLast, y <- prfTraces x] ++
+    showEntries 1 (concatMap prfTraces onlyLast)
     where
+        onlyLast = filter (\x -> prfBuilt x == 0) xs
         showEntries pid xs = map (showEntry pid) $ snd $ mapAccumL alloc [] $ sortOn prfStart xs
 
         alloc :: [ProfileTrace] -> ProfileTrace -> ([ProfileTrace], (Int, ProfileTrace))


### PR DESCRIPTION
Previously all information from the build database was included
in chrome profiles without any delineation between build runs.
This made chrome profiles difficult to comprehend.

This change now only writes the latest build run information
to the chrome profile.

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
