### PR TITLE
Fix negative timings in batch

### DIFF
--- a/src/Development/Shake/Internal/Core/Action.hs
+++ b/src/Development/Shake/Internal/Core/Action.hs
@@ -546,7 +546,7 @@ batch mx pred one many
             count <- liftIO $ atomicModifyIORef todo $ \(count, bs) -> let i = count+1 in ((i, (b,local,fence):bs), i)
             requeue todo (==) count
             (wait, local2) <- actionFenceRequeue fence
-            Action $ modifyRW $ \root -> addDiscount wait $ localMergeMutable root [local2]
+            Action $ modifyRW $ addDiscount wait
     where
         -- When changing by one, only trigger on (==) so we don't have lots of waiting pool entries
         -- When changing by many, trigger on (>=) because we don't hit all edges


### PR DESCRIPTION
My attempt to fix #752 . I *think* this addresses the problem, but I am not confident enough in the semantics of how the discounts are supposed to work to be sure.

I'd appreciate your input on this, as we'll be unable to use Shake on CI until we can give meaningful timing information.