### PR TITLE
.cabal: also use file-embed correctly for executable

### DIFF
--- a/shake.cabal
+++ b/shake.cabal
@@ -234,7 +234,8 @@ executable shake
         unordered-containers >= 0.2.7,
         utf8-string >= 0.3
 
-    cpp-options: -DFILE_EMBED
+    if flag(embed-files)
+        cpp-options: -DFILE_EMBED
 
     if flag(portable)
         cpp-options: -DPORTABLE


### PR DESCRIPTION
Use the `file-embed` flag too for the executable target.
Before this it was not possible to disable `-DFILE_EMBED` completely.

Fixes #768

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
