### PR TITLE
Collect reverse dependencies

### DIFF
--- a/model/Model.md
+++ b/model/Model.md
@@ -92,6 +92,7 @@ For those who like concrete details, which might change at any point in the futu
         ,built     :: Step    -- when it was actually run
         ,changed   :: Step    -- when the result last changed
         ,depends   :: [[Id]]  -- dependencies
+        ,rdepends  :: [Id]    -- reverse dependencies
         ,execution :: Float   -- duration of last run
         ,traces    :: [Trace] -- a trace of the expensive operations
         } deriving Show
@@ -180,13 +181,13 @@ isn't the case, and "output" would still be clean.
 >
 > In you rule `File -(ModTime, [(File, ModTime)]`. Is the time stored for a dependency
 >
-> 1 - the time the dependency has been last used 
+> 1 - the time the dependency has been last used
 >
 > 2 - the dependency last modification when the dependency has been used?
 >
 > For example. Let's say B depends on A and A has been modified yesterday.
 >
-> If I'm building B today: scenario (1) would be store 
+> If I'm building B today: scenario (1) would be store
 >
 > database B = (Today, [(A, Today)])
 >

--- a/src/Development/Shake.hs
+++ b/src/Development/Shake.hs
@@ -123,6 +123,7 @@ import Development.Shake.Internal.Value
 import Development.Shake.Internal.Options
 import Development.Shake.Internal.Core.Types
 import Development.Shake.Internal.Core.Action
+import Development.Shake.Internal.Core.Build
 import Development.Shake.Internal.Core.Rules
 import Development.Shake.Internal.Resource
 import Development.Shake.Internal.Derived

--- a/src/Development/Shake.hs
+++ b/src/Development/Shake.hs
@@ -138,7 +138,6 @@ import Development.Shake.Internal.Rules.File
 import Development.Shake.Internal.Rules.Files
 import Development.Shake.Internal.Rules.Oracle
 import Development.Shake.Internal.Rules.OrderOnly
-import Development.Shake.Internal.Rules.Rerun
 
 -- $writing
 --

--- a/src/Development/Shake/Database.hs
+++ b/src/Development/Shake/Database.hs
@@ -21,6 +21,7 @@ module Development.Shake.Database(
     shakeOneShotDatabase,
     shakeRunDatabase,
     shakeRunDatabaseForKeys,
+    SomeShakeValue(..),
     shakeLiveFilesDatabase,
     shakeProfileDatabase,
     shakeErrorsDatabase,
@@ -39,7 +40,7 @@ import Development.Shake.Internal.Core.Rules
 import Development.Shake.Internal.Core.Run
 import Development.Shake.Internal.Core.Types
 import Development.Shake.Internal.Rules.Default
-import Development.Shake.Internal.Value (ShakeValue)
+import Development.Shake.Internal.Value (ShakeValue, SomeShakeValue(..))
 
 
 data UseState
@@ -137,7 +138,7 @@ shakeErrorsDatabase (ShakeDatabase use s) =
 --   actions along with a list of actions to run after the database was closed, as added with
 --   'Development.Shake.runAfter' and 'Development.Shake.removeFilesAfter'.
 shakeRunDatabase :: ShakeDatabase -> [Action a] -> IO ([a], [IO ()])
-shakeRunDatabase = shakeRunDatabaseForKeys (Nothing :: Maybe [()])
+shakeRunDatabase = shakeRunDatabaseForKeys Nothing
 
 -- | Given an open 'ShakeDatabase', run both whatever actions were added to the 'Rules',
 --   plus the list of 'Action' given here.
@@ -151,8 +152,7 @@ shakeRunDatabase = shakeRunDatabaseForKeys (Nothing :: Maybe [()])
 --   of actions to run after the database was closed, as added with
 --   'Development.Shake.runAfter' and 'Development.Shake.removeFilesAfter'.
 shakeRunDatabaseForKeys
-    :: ShakeValue key
-    => Maybe [key]       -- ^ Set of keys changed since last run
+    :: Maybe [SomeShakeValue]       -- ^ Set of keys changed since last run
     -> ShakeDatabase
     -> [Action a]
     -> IO ([a], [IO ()])

--- a/src/Development/Shake/Database.hs
+++ b/src/Development/Shake/Database.hs
@@ -135,8 +135,16 @@ shakeErrorsDatabase (ShakeDatabase use s) =
 --   plus the list of 'Action' given here. Returns the results from the explicitly passed
 --   actions along with a list of actions to run after the database was closed, as added with
 --   'Development.Shake.runAfter' and 'Development.Shake.removeFilesAfter'.
-shakeRunDatabase :: ShakeValue key => ShakeDatabase -> Maybe [key] -> [Action a] -> IO ([a], [IO ()])
-shakeRunDatabase (ShakeDatabase use s) keysChanged as =
+shakeRunDatabase :: ShakeDatabase -> [Action a] -> IO ([a], [IO ()])
+shakeRunDatabase = shakeRunDatabaseForKeys (Nothing :: Maybe [()])
+
+-- | Given an open 'ShakeDatabase', run both whatever actions were added to the 'Rules',
+--   plus the list of 'Action' given here, for a subset of the keys (or all if 'Nothing').
+--   Returns the results from the explicitly passed
+--   actions along with a list of actions to run after the database was closed, as added with
+--   'Development.Shake.runAfter' and 'Development.Shake.removeFilesAfter'.
+shakeRunDatabaseForKeys :: ShakeValue key => Maybe [key] -> ShakeDatabase -> [Action a] -> IO ([a], [IO ()])
+shakeRunDatabaseForKeys keysChanged (ShakeDatabase use s) as =
     withOpen use "shakeRunDatabase" (\o -> o{openRequiresReset=True}) $ \Open{..} -> do
         when openRequiresReset $ do
             when openOneShot $

--- a/src/Development/Shake/Database.hs
+++ b/src/Development/Shake/Database.hs
@@ -143,8 +143,9 @@ shakeRunDatabase = shakeRunDatabaseForKeys (Nothing :: Maybe [()])
 --   plus the list of 'Action' given here.
 --
 --   If a set of dirty keys is given, only the reverse dependencies of these keys
---   will be considered potentially changed; all other keys will be assumed unchanged
---   except for the 'alwaysRerun' key which is always included in the dirty set.
+--   will be considered potentially changed; all other keys will be assumed unchanged.
+--   This includes the 'AlwaysRerunQ' key which is by default always dirty, but
+--   will not here, unless it is included in the input.
 --
 --   Returns the results from the explicitly passed actions along with a list
 --   of actions to run after the database was closed, as added with

--- a/src/Development/Shake/Database.hs
+++ b/src/Development/Shake/Database.hs
@@ -32,8 +32,11 @@ module Development.Shake.Database(
 import Control.Concurrent.Extra
 import Control.Exception
 import Control.Monad
+import Control.Monad.Extra (whenJust)
 import Control.Monad.IO.Class
+import qualified Data.HashSet as HashSet
 import Data.IORef
+import Data.Maybe
 import General.Cleanup
 import Development.Shake.Internal.Errors
 import Development.Shake.Internal.Options
@@ -41,11 +44,8 @@ import Development.Shake.Internal.Core.Rules
 import Development.Shake.Internal.Core.Run
 import Development.Shake.Internal.Core.Types
 import Development.Shake.Internal.Rules.Default
-import Development.Shake.Internal.Value (ShakeValue, SomeShakeValue(..), newKey)
-import Data.Maybe (isJust, mapMaybe, fromMaybe)
+import Development.Shake.Internal.Value (SomeShakeValue(..), newKey)
 import Development.Shake.Internal.Core.Database (markDirty, getIdFromKey)
-import Control.Monad.Extra (whenJust)
-import qualified Data.HashSet as HashSet
 
 
 data UseState

--- a/src/Development/Shake/Database.hs
+++ b/src/Development/Shake/Database.hs
@@ -20,6 +20,7 @@ module Development.Shake.Database(
     shakeWithDatabase,
     shakeOneShotDatabase,
     shakeRunDatabase,
+    shakeRunDatabaseForKeys,
     shakeLiveFilesDatabase,
     shakeProfileDatabase,
     shakeErrorsDatabase,

--- a/src/Development/Shake/Database.hs
+++ b/src/Development/Shake/Database.hs
@@ -45,7 +45,7 @@ import Development.Shake.Internal.Core.Run
 import Development.Shake.Internal.Core.Types
 import Development.Shake.Internal.Rules.Default
 import Development.Shake.Internal.Value (SomeShakeValue(..), newKey)
-import Development.Shake.Internal.Core.Database (markDirty, getIdFromKey)
+import Development.Shake.Internal.Core.Database (flushDirty, markDirty, getIdFromKey, runLocked)
 
 
 data UseState
@@ -169,6 +169,7 @@ shakeRunDatabaseForKeys keysChanged (ShakeDatabase use s) as = uninterruptibleMa
             when openOneShot $
                 throwM $ errorStructured "Error when calling shakeRunDatabase twice, after calling shakeOneShotDatabase" [] ""
             reset s
+            runLocked (database s) $ flushDirty (database s)
 
         -- record the keys changed and continue
         whenJust keysChanged $ \kk -> do

--- a/src/Development/Shake/Database.hs
+++ b/src/Development/Shake/Database.hs
@@ -148,6 +148,8 @@ shakeRunDatabase = shakeRunDatabaseForKeys Nothing
 -- | Given an open 'ShakeDatabase', run both whatever actions were added to the 'Rules',
 --   plus the list of 'Action' given here.
 --
+--   Requires 'shakeReverseDependencies', otherwise it falls back to 'shakeRunDatabase'.
+--
 --   If a set of dirty keys is given, only the reverse dependencies of these keys
 --   will be considered potentially changed; all other keys will be assumed unchanged.
 --   This includes the 'AlwaysRerunQ' key which is by default always dirty, but

--- a/src/Development/Shake/Internal/Args.hs
+++ b/src/Development/Shake/Internal/Args.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Command line parsing flags.
 module Development.Shake.Internal.Args(
@@ -47,7 +48,7 @@ shake opts rules = do
     addTiming "Function shake"
     (_, after) <- shakeWithDatabase opts rules $ \db -> do
         shakeOneShotDatabase db
-        shakeRunDatabase db []
+        shakeRunDatabase db (Nothing @[()]) []
     shakeRunAfter opts after
 
 

--- a/src/Development/Shake/Internal/Args.hs
+++ b/src/Development/Shake/Internal/Args.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- | Command line parsing flags.
 module Development.Shake.Internal.Args(

--- a/src/Development/Shake/Internal/Args.hs
+++ b/src/Development/Shake/Internal/Args.hs
@@ -48,7 +48,7 @@ shake opts rules = do
     addTiming "Function shake"
     (_, after) <- shakeWithDatabase opts rules $ \db -> do
         shakeOneShotDatabase db
-        shakeRunDatabase db (Nothing @[()]) []
+        shakeRunDatabase db []
     shakeRunAfter opts after
 
 

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -32,14 +32,13 @@ import Control.Exception
 import Control.Monad.Extra
 import Numeric.Extra
 import qualified Data.HashMap.Strict as Map
+import qualified Data.HashSet as HashSet
 import Development.Shake.Internal.Core.Rules
 import Data.Typeable
 import Data.Maybe
 import Data.List.Extra
 import Data.Either.Extra
 import System.Time.Extra
-import qualified Data.HashSet as HashSet
-import Data.Functor ((<&>))
 
 
 ---------------------------------------------------------------------

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -152,8 +152,8 @@ updateReverseDeps myId db prev new = do
         updateResult f (Ready r) = Ready $ f r
         updateResult f (Failed e r) = Failed e (fmap f r)
         updateResult f (Loaded r) = Loaded $ addDep r
-        updateResult _ Running{} = error "Running"
-        updateResult _ Missing{} = error "Missing"
+        updateResult _ Running{} = error "Running: can this happen?"
+        updateResult _ Missing{} = error "Missing: can this happen?"
 
 -- | Compute the value for a given RunMode and a restore function to run
 buildRunMode :: Global -> Stack -> Database -> Maybe (Result a) -> Wait Locked RunMode

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -132,6 +132,7 @@ buildOne global@Global{..} stack database i k r = case addStack i k stack of
 
 -- | Refresh all the reverse dependencies
 --   Assumes that none of them is running
+{-# SCC updateReverseDeps #-}
 updateReverseDeps :: Id -> Database -> Maybe [Depends] -> [Depends] -> Locked ()
 updateReverseDeps myId db prev new = do
     let added = foldMap fromDepends new

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -102,7 +102,7 @@ buildOne global@Global{..} stack database i k r = case addStack i k stack of
         pure $ Left e
     Right stack -> Later $ \continue -> do
         setIdKeyStatus global database i k (Running (NoShow continue) r)
-        let go = buildRunMode global stack database (fmap (\r -> r{result = i}) r)
+        let go = buildRunMode global stack database i r
         fromLater go $ \mode -> liftIO $ addPool PoolStart globalPool $
             runKey global stack k r mode $ \result -> do
                 runLocked database $ do
@@ -159,27 +159,27 @@ updateReverseDeps myId db prev new = do
         updateResult _ Missing{} = error "Missing: can this happen?"
 
 -- | Compute the value for a given RunMode and a restore function to run
-buildRunMode :: Global -> Stack -> Database -> Maybe (Result Id) -> Wait Locked RunMode
-buildRunMode global stack database me = do
-    changed <- case me of
+buildRunMode :: Global -> Stack -> Database -> Id -> Maybe (Result a) -> Wait Locked RunMode
+buildRunMode global stack database i r = do
+    changed <- case r of
         Nothing -> pure True
-        Just me -> buildRunDependenciesChanged global stack database me
+        Just me -> buildRunDependenciesChanged global stack database i me
     pure $ if changed then RunDependenciesChanged else RunDependenciesSame
 
 
 -- | Have the dependencies changed
-buildRunDependenciesChanged :: Global -> Stack -> Database -> Result Id -> Wait Locked Bool
-buildRunDependenciesChanged global stack database me
+buildRunDependenciesChanged :: Global -> Stack -> Database -> Id -> Result a -> Wait Locked Bool
+buildRunDependenciesChanged global stack database i r
   | Just dirtySet <- globalDirtySet global
-  , not (result me `HashSet.member` dirtySet)
+  , not (i `HashSet.member` dirtySet)
   -- If I am not in the dirty set then none of my dependencies are, so they must be unchanged
   = pure False
 -- If I am in the dirty set, it is still possible that all my dependencies are unchanged
   -- thanks to early cutoff, and therefore we must check to avoid redundant work
   | otherwise = isJust <$> firstJustM id
-    [firstJustWaitUnordered (fmap test . lookupOne global stack database) x | Depends x <- depends me]
+    [firstJustWaitUnordered (fmap test . lookupOne global stack database) x | Depends x <- depends r]
     where
-        test (Right dep) | changed dep <= built me = Nothing
+        test (Right dep) | changed dep <= built r = Nothing
         test _ = Just ()
 
 

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -147,15 +147,9 @@ updateReverseDeps myId db prev new = do
         doOne f id = do
             kv <- liftIO $ getKeyValueFromId db id
             whenJust kv $ \(k,v) -> do
-                whenJust (getRDepsFromResult v) $ \r ->
-                    liftIO $ atomicModifyIORef_ r f
-
-        getRDepsFromResult :: Status -> Maybe (IORef (HashSet.HashSet Id))
-        getRDepsFromResult (Ready r) = rdepends r
-        getRDepsFromResult (Failed e r) = rdepends =<< r
-        getRDepsFromResult (Loaded r) = rdepends r
-        getRDepsFromResult Running{} = error "Running: can this happen?"
-        getRDepsFromResult Missing{} = error "Missing: can this happen?"
+                whenJust (getResult v) $ \r ->
+                    whenJust (rdepends r) $ \ref ->
+                    liftIO $ atomicModifyIORef_ ref f
 
 -- | Compute the value for a given RunMode and a restore function to run
 buildRunMode :: Global -> Stack -> Database -> Id -> Maybe (Result a) -> Wait Locked RunMode

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -119,7 +119,7 @@ buildOne global@Global{..} stack database i k r = case addStack i k stack of
                     case result of
                         Right RunResult{..} | runChanged `elem` [ChangedRecomputeDiff, ChangedRecomputeSame ] ->
                             updateReverseDeps i database (depends <$> r) (depends runValue)
-                        _ -> return ()
+                        _ -> pure ()
 
                     w val
                 case result of

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -135,9 +135,8 @@ buildOne global@Global{..} stack database i k r = case addStack i k stack of
 
 
 -- | Refresh all the reverse dependencies of an id
-{-# SCC updateReverseDeps #-}
 updateReverseDeps :: Id -> Database -> Maybe [Depends] -> [Depends] -> Locked ()
-updateReverseDeps myId db prev new = do
+updateReverseDeps myId db prev new = {-# SCC "updateReverseDeps" #-} do
     let added = foldMap fromDepends new
         deleted = [] -- an efficient impl. is expensive in space, so we overestimate for now
     forM_ added   $ doOne (HashSet.insert myId)

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -37,7 +37,6 @@ import Data.List.Extra
 import Data.Either.Extra
 import System.Time.Extra
 import qualified Data.HashSet as HashSet
-import Data.IORef.Extra (atomicModifyIORef_, IORef, newIORef)
 
 
 ---------------------------------------------------------------------

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -154,7 +154,7 @@ updateReverseDeps myId db prev new = do
         updateResult :: (forall a. Result a -> Result a) -> Status -> Status
         updateResult f (Ready r) = Ready $ f r
         updateResult f (Failed e r) = Failed e (fmap f r)
-        updateResult f (Loaded r) = Loaded $ addDep r
+        updateResult f (Loaded r) = Loaded $ f r
         updateResult _ Running{} = error "Running: can this happen?"
         updateResult _ Missing{} = error "Missing: can this happen?"
 

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -135,13 +135,12 @@ buildOne global@Global{..} stack database i k r = case addStack i k stack of
 
 
 
--- | Refresh all the reverse dependencies
---   Assumes that none of them is running
+-- | Refresh all the reverse dependencies of an id
 {-# SCC updateReverseDeps #-}
 updateReverseDeps :: Id -> Database -> Maybe [Depends] -> [Depends] -> Locked ()
 updateReverseDeps myId db prev new = do
     let added = foldMap fromDepends new
-        deleted = [] -- Does not have an efficient impl. so we overestimate for now
+        deleted = [] -- an efficient impl. is expensive in space, so we overestimate for now
     forM_ added   $ doOne (HashSet.insert myId)
     forM_ deleted $ doOne (HashSet.delete myId)
     where

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -263,7 +263,7 @@ runKey global@Global{globalOptions=ShakeOptions{..},..} stack k r mode continue 
                         ,changed = c
                         ,built = globalStep
                         ,depends = flattenDepends localDepends
-                        ,rdepends = mempty
+                        ,rdepends = maybe mempty rdepends r
                         ,execution = doubleToFloat $ dur - localDiscount
                         ,traces = flattenTraces localTraces}
             where

--- a/src/Development/Shake/Internal/Core/Build.hs
+++ b/src/Development/Shake/Internal/Core/Build.hs
@@ -121,7 +121,9 @@ buildOne global@Global{..} stack database i k r = case addStack i k stack of
 
                         -- update reverse dependencies efficiently - have they changed since last time?
                         case result of
-                            Right RunResult{..} | runChanged `elem` [ChangedRecomputeDiff, ChangedRecomputeSame ] ->
+                            Right RunResult{..}
+                             | shakeReverseDependencies globalOptions &&
+                                runChanged `elem` [ChangedRecomputeDiff, ChangedRecomputeSame ] ->
                                 updateReverseDeps i database (depends <$> r) (depends runValue)
                             _ -> pure ()
 

--- a/src/Development/Shake/Internal/Core/Database.hs
+++ b/src/Development/Shake/Internal/Core/Database.hs
@@ -3,6 +3,7 @@
 
 module Development.Shake.Internal.Core.Database(
     Locked, runLocked,
+    maskLocked,
     DatabasePoly, createDatabase,
     mkId,
     getValueFromKey, getIdFromKey, getKeyValues, getKeyValueFromId, getKeyValuesFromId,
@@ -20,6 +21,7 @@ import Control.Monad.IO.Class
 import qualified General.Ids as Ids
 import Control.Monad.Fail
 import Prelude
+import Control.Exception (mask_)
 
 
 newtype Locked a = Locked (IO a)
@@ -28,6 +30,8 @@ newtype Locked a = Locked (IO a)
 runLocked :: DatabasePoly k v -> Locked b -> IO b
 runLocked db (Locked act) = withLock (lock db) act
 
+maskLocked :: Locked a -> Locked a
+maskLocked (Locked act) = Locked $ mask_ act
 
 -- | Invariant: The database does not have any cycles where a Key depends on itself.
 --   Everything is mutable. intern and status must form a bijecttion.

--- a/src/Development/Shake/Internal/Core/Database.hs
+++ b/src/Development/Shake/Internal/Core/Database.hs
@@ -25,7 +25,6 @@ import Prelude
 import Control.Exception (mask_)
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as HSet
-import Data.List (foldl')
 
 
 newtype Locked a = Locked (IO a)

--- a/src/Development/Shake/Internal/Core/Database.hs
+++ b/src/Development/Shake/Internal/Core/Database.hs
@@ -8,7 +8,7 @@ module Development.Shake.Internal.Core.Database(
     mkId,
     getValueFromKey, getIdFromKey, getKeyValues, getKeyValueFromId, getKeyValuesFromId,
     setMem, setDisk, modifyAllMem,
-    isDirty, markDirty, unmarkDirty
+    isDirty, getDirtySet, markDirty, unmarkDirty
     ) where
 
 import Data.Tuple.Extra
@@ -93,6 +93,9 @@ getIdFromKey Database{..} = do
 
 isDirty :: DatabasePoly k v -> Id -> IO Bool
 isDirty Database{..} i = HSet.member i <$> readIORef dirty
+
+getDirtySet :: DatabasePoly k v -> IO (HashSet Id)
+getDirtySet Database{..} = readIORef dirty
 
 ---------------------------------------------------------------------
 -- MUTATING

--- a/src/Development/Shake/Internal/Core/Database.hs
+++ b/src/Development/Shake/Internal/Core/Database.hs
@@ -7,7 +7,8 @@ module Development.Shake.Internal.Core.Database(
     DatabasePoly, createDatabase,
     mkId,
     getValueFromKey, getIdFromKey, getKeyValues, getKeyValueFromId, getKeyValuesFromId,
-    setMem, setDisk, modifyAllMem
+    setMem, setDisk, modifyAllMem,
+    isDirty, markDirty, unmarkDirty
     ) where
 
 import Data.Tuple.Extra
@@ -22,6 +23,9 @@ import qualified General.Ids as Ids
 import Control.Monad.Fail
 import Prelude
 import Control.Exception (mask_)
+import Data.HashSet (HashSet)
+import qualified Data.HashSet as HSet
+import Data.List (foldl')
 
 
 newtype Locked a = Locked (IO a)
@@ -43,6 +47,8 @@ data DatabasePoly k v = Database
     ,status :: Ids.Ids (k, v) -- ^ Id |-> (Key, Status) mapping
     ,journal :: Id -> k -> v -> IO () -- ^ Record all changes to status
     ,vDefault :: v
+    ,dirty :: IORef (HashSet Id)
+    -- ^ An approximation of the dirty set across runs of 'shakeRunDatabaseForKeys'
     }
 
 
@@ -56,6 +62,7 @@ createDatabase status journal vDefault = do
     xs <- Ids.toList status
     intern <- newIORef $ Intern.fromList [(k, i) | (i, (k,_)) <- xs]
     lock <- newLock
+    dirty <- newIORef mempty
     pure Database{..}
 
 
@@ -84,6 +91,8 @@ getIdFromKey Database{..} = do
     is <- readIORef intern
     pure $ flip Intern.lookup is
 
+isDirty :: DatabasePoly k v -> Id -> IO Bool
+isDirty Database{..} i = HSet.member i <$> readIORef dirty
 
 ---------------------------------------------------------------------
 -- MUTATING
@@ -112,3 +121,10 @@ modifyAllMem Database{..} f = liftIO $ Ids.forMutate status $ \(k,v) ->
 
 setDisk :: DatabasePoly k v -> Id -> k -> v -> IO ()
 setDisk = journal
+
+markDirty :: DatabasePoly k v -> HashSet Id -> IO ()
+markDirty Database{..} ids = atomicModifyIORef'_ dirty $ HSet.union ids
+
+unmarkDirty :: DatabasePoly k v -> Id -> IO ()
+unmarkDirty Database{..} i = do
+    atomicModifyIORef'_ dirty (HSet.delete i)

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -212,7 +212,7 @@ computeTransitiveChanges diag database (Just keys) = do
     diag $ pure $
         printf "%d transitive changes computed for: %s" (Set.size transitive) (show keys)
 
-    return $ Just transitive
+    pure $ Just transitive
 
 -- | Run a set of IO actions, treated as \"after\" actions, typically returned from
 --   'Development.Shake.Database.shakeRunDatabase'. The actions will be run with diagnostics

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -200,8 +200,7 @@ computeDirtySet :: ShakeValue key => (IO String -> IO()) -> Database -> Maybe [k
 computeDirtySet _ _ Nothing = pure Nothing
 computeDirtySet diag database (Just keys) = do
     getId <- getIdFromKey database
-    let ids = maybeToList (getId $ newKey $ AlwaysRerunQ ())
-            <> mapMaybe (getId . newKey) keys
+    let ids = mapMaybe (getId . newKey) keys
         loop x = do
             seen <- State.get
             if x `Set.member` seen then pure () else do

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -21,6 +21,7 @@ import Data.Tuple.Extra
 import Control.Concurrent.Extra hiding (withNumCapabilities)
 import Development.Shake.Internal.Core.Database
 import Control.Monad.IO.Class
+import qualified Control.Monad.Trans.State.Strict as State
 import General.Binary
 import Development.Shake.Classes
 import Development.Shake.Internal.Core.Storage
@@ -54,14 +55,11 @@ import General.Timing
 import General.Thread
 import General.Extra
 import General.Cleanup
+import qualified General.Ids as Ids
+import Data.Foldable (traverse_)
 import Data.Monoid
 import Prelude
-import General.Ids (Id)
-import qualified Control.Monad.Trans.State.Strict as State
-import Data.Foldable (traverse_)
 import Text.Printf
-import Development.Shake.Internal.Rules.Rerun (AlwaysRerunQ(AlwaysRerunQ))
-import qualified General.Ids as Ids
 
 
 ---------------------------------------------------------------------

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -148,7 +148,7 @@ run keysChanged RunState{..} oneshot actions2 =
             addTiming "Running rules"
             locals <- newIORef []
 
-            transitiveChanges <- computeTransitiveChanges diagnostic database keysChanged
+            transitiveChanges <- computeDirtySet diagnostic database keysChanged
 
             runPool (shakeThreads == 1) shakeThreads $ \pool -> do
                 let global = Global applyKeyValue database pool cleanup start builtinRules output opts diagnostic ruleFinished after absent getProgress userRules shared cloud step oneshot transitiveChanges
@@ -196,10 +196,10 @@ run keysChanged RunState{..} oneshot actions2 =
             putStr . unlines
         pure res
 
-{-# SCC computeTransitiveChanges #-}
-computeTransitiveChanges :: ShakeValue key => (IO String -> IO()) -> Database -> Maybe [key] -> IO (Maybe (Set.HashSet Id))
-computeTransitiveChanges _ _ Nothing = pure Nothing
-computeTransitiveChanges diag database (Just keys) = do
+{-# SCC computeDirtySet #-}
+computeDirtySet :: ShakeValue key => (IO String -> IO()) -> Database -> Maybe [key] -> IO (Maybe (Set.HashSet Id))
+computeDirtySet _ _ Nothing = pure Nothing
+computeDirtySet diag database (Just keys) = do
     getId <- getIdFromKey database
     let ids = maybeToList (getId $ newKey $ AlwaysRerunQ ())
             <> mapMaybe (getId . newKey) keys

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -196,6 +196,7 @@ run keysChanged RunState{..} oneshot actions2 =
             putStr . unlines
         pure res
 
+{-# SCC computeTransitiveChanges #-}
 computeTransitiveChanges :: ShakeValue key => (IO String -> IO()) -> Database -> Maybe [key] -> IO (Maybe (Set.HashSet Id))
 computeTransitiveChanges _ _ Nothing = pure Nothing
 computeTransitiveChanges diag database (Just keys) = do

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -56,7 +56,6 @@ import Data.Monoid
 import Prelude
 import General.Ids (Id)
 import qualified Control.Monad.Trans.State.Strict as State
-import Control.Monad.Trans.Class (lift)
 import Data.Foldable (traverse_)
 import Text.Printf
 import Development.Shake.Internal.Rules.Rerun (AlwaysRerunQ(AlwaysRerunQ))

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -59,6 +59,7 @@ import qualified Control.Monad.Trans.State.Strict as State
 import Control.Monad.Trans.Class (lift)
 import Data.Foldable (traverse_)
 import Text.Printf
+import Development.Shake.Internal.Rules.Rerun (AlwaysRerunQ(AlwaysRerunQ))
 
 
 ---------------------------------------------------------------------
@@ -199,7 +200,8 @@ computeTransitiveChanges :: ShakeValue key => (IO String -> IO()) -> Database ->
 computeTransitiveChanges _ _ Nothing = pure Nothing
 computeTransitiveChanges diag database (Just keys) = do
     getId <- getIdFromKey database
-    let ids = mapMaybe (getId . newKey) keys
+    let ids = maybeToList (getId $ newKey $ AlwaysRerunQ ())
+            <> mapMaybe (getId . newKey) keys
         loop x = do
             seen <- State.get
             if x `Set.member` seen then pure () else do

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -202,9 +202,8 @@ run RunState{..} oneshot useDirtySet actions2 =
         pure res
 
 -- | Transitively expand the dirty set
-{-# SCC updateDirtySet #-}
 updateDirtySet :: (IO String -> IO()) -> Database -> IO ()
-updateDirtySet diag database = do
+updateDirtySet diag database = {-# SCC updateDirtySet #-} do
     let loop x = do
             seen <- State.get
             if x `Set.member` seen then pure () else do

--- a/src/Development/Shake/Internal/Core/Run.hs
+++ b/src/Development/Shake/Internal/Core/Run.hs
@@ -153,10 +153,11 @@ run RunState{..} oneshot useDirtySet actions2 =
             addTiming "Running rules"
             locals <- newIORef []
 
-            when useDirtySet $ updateDirtySet diagnostic database
+            let reallyUseDirtySet = useDirtySet && shakeReverseDependencies
+            when reallyUseDirtySet $ updateDirtySet diagnostic database
 
             runPool (shakeThreads == 1) shakeThreads $ \pool -> do
-                let global = Global applyKeyValue database pool cleanup start builtinRules output opts diagnostic ruleFinished after absent getProgress userRules shared cloud step oneshot useDirtySet
+                let global = Global applyKeyValue database pool cleanup start builtinRules output opts diagnostic ruleFinished after absent getProgress userRules shared cloud step oneshot reallyUseDirtySet
                 -- give each action a stack to start with!
                 forM_ (actions ++ map (emptyStack,) actions2) $ \(stack, act) -> do
                     let local = newLocal stack shakeVerbosity

--- a/src/Development/Shake/Internal/Core/Types.hs
+++ b/src/Development/Shake/Internal/Core/Types.hs
@@ -50,7 +50,6 @@ import Data.Semigroup
 import General.Cleanup
 import Control.Monad.Fail
 import Prelude
-import Data.HashSet (HashSet)
 
 
 ---------------------------------------------------------------------

--- a/src/Development/Shake/Internal/Core/Types.hs
+++ b/src/Development/Shake/Internal/Core/Types.hs
@@ -50,6 +50,7 @@ import Data.Semigroup
 import General.Cleanup
 import Control.Monad.Fail
 import Prelude
+import Data.HashSet (HashSet)
 
 
 ---------------------------------------------------------------------
@@ -237,13 +238,14 @@ data Result a = Result
     ,built :: {-# UNPACK #-} !Step -- ^ when it was actually run
     ,changed :: {-# UNPACK #-} !Step -- ^ the step for deciding if it's valid
     ,depends :: ![Depends] -- ^ dependencies (don't run them early)
+    ,rdepends :: !(HashSet Id) -- ^ reverse dependencies
     ,execution :: {-# UNPACK #-} !Float -- ^ how long it took when it was last run (seconds)
     ,traces :: ![Trace] -- ^ a trace of the expensive operations (start/end in seconds since beginning of run)
     } deriving (Show,Functor)
 
 instance NFData a => NFData (Result a) where
     -- ignore unpacked fields
-    rnf (Result a _ _ b _ c) = rnf a `seq` rnf b `seq` rnf c
+    rnf (Result a _ _ b _rdeps _ c) = rnf a `seq` rnf b `seq` rnf c
 
 statusType Ready{} = "Ready"
 statusType Failed{} = "Failed"
@@ -453,6 +455,7 @@ data Global = Global
     ,globalCloud :: Maybe Cloud
     ,globalStep :: {-# UNPACK #-} !Step
     ,globalOneShot :: Bool -- ^ I am running in one-shot mode so don't need to store BS's for Result/Failed
+    ,globalKeysChanged :: Maybe (HashSet Id)
     }
 
 -- local variables of Action

--- a/src/Development/Shake/Internal/Core/Types.hs
+++ b/src/Development/Shake/Internal/Core/Types.hs
@@ -455,7 +455,7 @@ data Global = Global
     ,globalCloud :: Maybe Cloud
     ,globalStep :: {-# UNPACK #-} !Step
     ,globalOneShot :: Bool -- ^ I am running in one-shot mode so don't need to store BS's for Result/Failed
-    ,globalKeysChanged :: Maybe (HashSet Id)
+    ,globalDirtySet :: Maybe (HashSet Id)
     }
 
 -- local variables of Action

--- a/src/Development/Shake/Internal/Core/Types.hs
+++ b/src/Development/Shake/Internal/Core/Types.hs
@@ -458,7 +458,7 @@ data Global = Global
     ,globalCloud :: Maybe Cloud
     ,globalStep :: {-# UNPACK #-} !Step
     ,globalOneShot :: Bool -- ^ I am running in one-shot mode so don't need to store BS's for Result/Failed
-    ,globalDirtySet :: Maybe (HashSet Id)
+    ,globalUseDirtySet :: Bool -- ^ Use the dirty set approximation when running rules
     }
 
 -- local variables of Action

--- a/src/Development/Shake/Internal/Core/Types.hs
+++ b/src/Development/Shake/Internal/Core/Types.hs
@@ -238,7 +238,6 @@ data Result a = Result
     ,built :: {-# UNPACK #-} !Step -- ^ when it was actually run
     ,changed :: {-# UNPACK #-} !Step -- ^ the step for deciding if it's valid
     ,depends :: ![Depends] -- ^ dependencies (don't run them early)
-    ,rdepends :: Maybe (IORef (HashSet Id)) -- ^ reverse dependencies
     ,execution :: {-# UNPACK #-} !Float -- ^ how long it took when it was last run (seconds)
     ,traces :: ![Trace] -- ^ a trace of the expensive operations (start/end in seconds since beginning of run)
     } deriving (Functor)
@@ -248,7 +247,7 @@ instance Show (Result a) where
 
 instance NFData a => NFData (Result a) where
     -- ignore unpacked fields
-    rnf (Result a _ _ b _rdeps _ c) = rnf a `seq` rnf b `seq` rnf c
+    rnf (Result a _ _ b _ c) = rnf a `seq` rnf b `seq` rnf c
 
 statusType Ready{} = "Ready"
 statusType Failed{} = "Failed"

--- a/src/Development/Shake/Internal/Core/Types.hs
+++ b/src/Development/Shake/Internal/Core/Types.hs
@@ -238,10 +238,13 @@ data Result a = Result
     ,built :: {-# UNPACK #-} !Step -- ^ when it was actually run
     ,changed :: {-# UNPACK #-} !Step -- ^ the step for deciding if it's valid
     ,depends :: ![Depends] -- ^ dependencies (don't run them early)
-    ,rdepends :: !(HashSet Id) -- ^ reverse dependencies
+    ,rdepends :: Maybe (IORef (HashSet Id)) -- ^ reverse dependencies
     ,execution :: {-# UNPACK #-} !Float -- ^ how long it took when it was last run (seconds)
     ,traces :: ![Trace] -- ^ a trace of the expensive operations (start/end in seconds since beginning of run)
-    } deriving (Show,Functor)
+    } deriving (Functor)
+
+instance Show (Result a) where
+    show _ = "<result>"
 
 instance NFData a => NFData (Result a) where
     -- ignore unpacked fields

--- a/src/Development/Shake/Internal/Options.hs
+++ b/src/Development/Shake/Internal/Options.hs
@@ -216,6 +216,9 @@ data ShakeOptions = ShakeOptions
         --   undefined results. Provided for compatibility with @ninja@.
     ,shakeAllowRedefineRules :: Bool
         -- ^ Whether to allow calling addBuiltinRule for the same key more than once
+    ,shakeReverseDependencies :: Bool
+        -- ^ Enables the tracking of reverse dependencies,
+        --   used by `shakeRunDatabaseForKeys' to reduce internal overheads when checking for rule freshness.
     ,shakeProgress :: IO Progress -> IO ()
         -- ^ Defaults to no action. A function called when the build starts, allowing progress to be reported.
         --   The function is called on a separate thread, and that thread is killed when the build completes.
@@ -240,7 +243,7 @@ data ShakeOptions = ShakeOptions
 shakeOptions :: ShakeOptions
 shakeOptions = ShakeOptions
     ".shake" 1 "1" Info False [] Nothing [] [] [] [] (Just 10) [] [] False True False
-    True ChangeModtime True [] False False Nothing [] False False False
+    True ChangeModtime True [] False False Nothing [] False False False False
     (const $ pure ())
     (const $ BS.putStrLn . UTF8.fromString) -- try and output atomically using BS
     (\_ _ _ -> pure ())
@@ -252,20 +255,20 @@ fieldsShakeOptions =
     ,"shakeFlush", "shakeRebuild", "shakeAbbreviations", "shakeStorageLog"
     ,"shakeLineBuffering", "shakeTimings", "shakeRunCommands", "shakeChange", "shakeCreationCheck"
     ,"shakeLiveFiles", "shakeVersionIgnore", "shakeColor", "shakeShare", "shakeCloud", "shakeSymlink"
-    ,"shakeNeedDirectory", "shakeCanRedefineRules"
+    ,"shakeNeedDirectory", "shakeCanRedefineRules", "shakeReverseDependencies"
     ,"shakeProgress", "shakeOutput", "shakeTrace", "shakeExtra"]
 tyShakeOptions = mkDataType "Development.Shake.Types.ShakeOptions" [conShakeOptions]
 conShakeOptions = mkConstr tyShakeOptions "ShakeOptions" fieldsShakeOptions Prefix
-unhide x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 y1 y2 y3 y4 =
-  ShakeOptions x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28
+unhide x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 y1 y2 y3 y4 =
+  ShakeOptions x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29
         (fromHidden y1) (fromHidden y2) (fromHidden y3) (fromHidden y4)
 
 instance Data ShakeOptions where
-    gfoldl k z (ShakeOptions x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 y1 y2 y3 y4) =
+    gfoldl k z (ShakeOptions x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 y1 y2 y3 y4) =
         z unhide `k` x1 `k` x2 `k` x3 `k` x4 `k` x5 `k` x6 `k` x7 `k` x8 `k` x9 `k` x10 `k` x11 `k`
-        x12 `k` x13 `k` x14 `k` x15 `k` x16 `k` x17 `k` x18 `k` x19 `k` x20 `k` x21 `k` x22 `k` x23 `k` x24 `k` x25 `k` x26 `k` x27 `k` x28 `k`
+        x12 `k` x13 `k` x14 `k` x15 `k` x16 `k` x17 `k` x18 `k` x19 `k` x20 `k` x21 `k` x22 `k` x23 `k` x24 `k` x25 `k` x26 `k` x27 `k` x28 `k` x29 `k`
         Hidden y1 `k` Hidden y2 `k` Hidden y3 `k` Hidden y4
-    gunfold k z _ = k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ z unhide
+    gunfold k z _ = k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ k $ z unhide
     toConstr ShakeOptions{} = conShakeOptions
     dataTypeOf _ = tyShakeOptions
 

--- a/src/Development/Shake/Internal/Rules/File.hs
+++ b/src/Development/Shake/Internal/Rules/File.hs
@@ -29,7 +29,6 @@ import Development.Shake.Internal.Core.Rules
 import Development.Shake.Internal.Core.Build
 import Development.Shake.Internal.Core.Action
 import Development.Shake.Internal.FileName
-import Development.Shake.Internal.Rules.Rerun
 import Development.Shake.Classes
 import Development.Shake.FilePath(toStandard)
 import Development.Shake.Internal.FilePattern

--- a/src/Development/Shake/Internal/Rules/Files.hs
+++ b/src/Development/Shake/Internal/Rules/Files.hs
@@ -20,7 +20,6 @@ import Development.Shake.Internal.Errors
 import General.Extra
 import Development.Shake.Internal.FileName
 import Development.Shake.Classes
-import Development.Shake.Internal.Rules.Rerun
 import Development.Shake.Internal.Rules.File
 import Development.Shake.Internal.FilePattern
 import Development.Shake.FilePath

--- a/src/Development/Shake/Internal/Rules/Rerun.hs
+++ b/src/Development/Shake/Internal/Rules/Rerun.hs
@@ -2,13 +2,11 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Development.Shake.Internal.Rules.Rerun(
-    defaultRuleRerun, alwaysRerun, AlwaysRerunQ(..)
+    defaultRuleRerun, AlwaysRerunQ(..)
     ) where
 
 import Development.Shake.Internal.Core.Rules
 import Development.Shake.Internal.Core.Types
-import Development.Shake.Internal.Core.Build
-import Development.Shake.Internal.Core.Action
 import Development.Shake.Classes
 import qualified Data.ByteString as BS
 import General.Binary
@@ -21,24 +19,6 @@ instance Show AlwaysRerunQ where show _ = "alwaysRerun"
 type instance RuleResult AlwaysRerunQ = ()
 
 
--- | Always rerun the associated action. Useful for defining rules that query
---   the environment. For example:
---
--- @
--- \"ghcVersion.txt\" 'Development.Shake.%>' \\out -> do
---     'alwaysRerun'
---     'Development.Shake.Stdout' stdout <- 'Development.Shake.cmd' \"ghc --numeric-version\"
---     'Development.Shake.writeFileChanged' out stdout
--- @
---
---   In @make@, the @.PHONY@ attribute on file-producing rules has a similar effect.
---
---   Note that 'alwaysRerun' is applied when a rule is executed. Modifying an existing rule
---   to insert 'alwaysRerun' will /not/ cause that rule to rerun next time.
-alwaysRerun :: Action ()
-alwaysRerun = do
-    historyDisable
-    apply1 $ AlwaysRerunQ ()
 
 defaultRuleRerun :: Rules ()
 defaultRuleRerun =

--- a/src/Development/Shake/Internal/Rules/Rerun.hs
+++ b/src/Development/Shake/Internal/Rules/Rerun.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Development.Shake.Internal.Rules.Rerun(
-    defaultRuleRerun, alwaysRerun
+    defaultRuleRerun, alwaysRerun, AlwaysRerunQ(..)
     ) where
 
 import Development.Shake.Internal.Core.Rules

--- a/src/Development/Shake/Internal/Value.hs
+++ b/src/Development/Shake/Internal/Value.hs
@@ -5,7 +5,7 @@
 module Development.Shake.Internal.Value(
     Value, newValue, fromValue,
     Key, newKey, fromKey, typeKey,
-    ShakeValue
+    ShakeValue, SomeShakeValue(..)
     ) where
 
 import Development.Shake.Classes
@@ -48,6 +48,12 @@ import Unsafe.Coerce
 -- * 'NFData' is used to avoid space and thunk leaks, especially
 --   when Shake is parallelized.
 type ShakeValue a = (Show a, Typeable a, Eq a, Hashable a, Binary a, NFData a)
+
+data SomeShakeValue = forall k . ShakeValue k => SomeShakeValue k
+
+instance Eq SomeShakeValue where SomeShakeValue a == SomeShakeValue b = cast a == Just b
+instance Hashable SomeShakeValue where hashWithSalt s (SomeShakeValue x) = hashWithSalt s x
+instance Show SomeShakeValue where show (SomeShakeValue x) = show x
 
 -- We deliberately avoid Typeable instances on Key/Value to stop them accidentally
 -- being used inside themselves


### PR DESCRIPTION
This PR makes the following changes:

* extends Shake to collect the reverse dependencies of every 'Result' by performing some bookkeeping on every evaluation. The amount of work done is O(E) on the number of edges in the graph and I have measured it to be around 3% for a very dense graph with 150.000 nodes and 1e8 edges, so it's not bad at all, and could be put behind a flag if desired. Note that in this PR the set of reverse dependencies is overestimated since ephemeral reverse edges are never deleted.

* adds a new function `shakeRunDatabaseFromKeys` which extends `shakeRunDatabase` by accepting, in addition to a set of actions (the goals), a set D of keys that have changed since the last run.  The transitive closure of D is the set of all keys that have potentially changed since the last run - all keys that do **not** belong to this set are guaranteed unchanged and can be excluded from the `buildRunDependenciesChanged` query. 

When the set D is small compared to the size of the build graph, this optimisation renders performance gains of one order of magnitude, up to ~70X~ 20X in some cases. I have extended[1] HLS to keep track of what has changed since the last **full** Shake run and performed several experiments:

* Applied the ghcide benchmark suite to the standard Cabal-3.0.0.0 example and obtained the results in the comments below.  The edit experiment runs in 55% of the time . [Full results](https://github.com/pepeiborra/ide/blob/keysChanged/ghcide/bench-results/unprofiled/Cabal-3.0.0.0/results.csv)
* Applied the ghcide benchmark suite to the standard lsp-1.0 example and obtained the results in the comments below.  The edit experiment runs in 73% of the time. [Full results](https://github.com/pepeiborra/ide/blob/keysChanged/ghcide/bench-results/unprofiled/lsp-types-1.0.0.1/results.csv)
* Applied the ghcide benchmark suite to a very large example involving a module with >17.000 transitive dependencies and measured the performance of the edit benchmark, which runs in 4.75% of the time i.e. >21X faster.

[1] - https://github.com/pepeiborra/ide/tree/keysChanged

Closes #800 

EDIT: updated performance numbers