### PR TITLE
Heterogeneous concurrent apply

### DIFF
--- a/src/Development/Shake/Rule.hs
+++ b/src/Development/Shake/Rule.hs
@@ -21,6 +21,8 @@ module Development.Shake.Rule(
     -- * Calling builtin rules
     -- | Wrappers around calling Shake rules. In general these should be specialised to a builtin rule.
     apply, apply1,
+    -- * Applicative parallel rule evaluation
+    Apply, apply', applyConcurrently,
     -- * User rules
     -- | Define user rules that can be used by builtin rules.
     --   Absent any builtin rule making use of a user rule at a given type, a user rule will have on effect -


### PR DESCRIPTION
We want to use rule parallelism in ghcide, but our user rules have heterogeneous key and result types.

The Apply applicative is to Shake as the Concurrently applicative is to async.

For an example of the intended usage, see:

https://github.com/haskell/haskell-language-server/commit/dfeb649f01ca30a692f366f5eacb402376de370e
