### PR TITLE
Fix documentation for `Stdin`

### DIFF
--- a/src/Development/Shake/Internal/CmdOption.hs
+++ b/src/Development/Shake/Internal/CmdOption.hs
@@ -12,7 +12,7 @@ data CmdOption
     | AddEnv String String -- ^ Add an environment variable in the child process.
     | RemEnv String -- ^ Remove an environment variable from the child process.
     | AddPath [String] [String] -- ^ Add some items to the prefix and suffix of the @$PATH@ variable.
-    | Stdin String -- ^ Given as the @stdin@ of the spawned process. By default the @stdin@ is inherited.
+    | Stdin String -- ^ Given as the @stdin@ of the spawned process.
     | StdinBS LBS.ByteString -- ^ Given as the @stdin@ of the spawned process.
     | FileStdin FilePath -- ^ Take the @stdin@ from a file.
     | Shell -- ^ Pass the command to the shell without escaping - any arguments will be joined with spaces. By default arguments are escaped properly.


### PR DESCRIPTION
This docstring claimed that `stdin` was by default inherited from the parent process. I think since https://github.com/ndmitchell/shake/commit/db861c3dab925b3cb3e3b6088f2e59461738331f and https://github.com/ndmitchell/shake/commit/102ecfc0c36c5a989db0b1cabad0f4e31a04acf8 that's not true anymore.
