### PR TITLE
Fix space leak in modifyAllMem

### DIFF
--- a/src/Development/Shake/Internal/Core/Database.hs
+++ b/src/Development/Shake/Internal/Core/Database.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving, RecordWildCards #-}
 
 module Development.Shake.Internal.Core.Database(
@@ -101,7 +102,9 @@ setMem :: DatabasePoly k v -> Id -> k -> v -> Locked ()
 setMem Database{..} i k v = liftIO $ Ids.insert status i (k,v)
 
 modifyAllMem :: DatabasePoly k v -> (v -> v) -> Locked ()
-modifyAllMem Database{..} f = liftIO $ Ids.forMutate status $ second f
+modifyAllMem Database{..} f = liftIO $ Ids.forMutate status $ \(k,v) ->
+    let !v' = f v
+    in (k, v')
 
 setDisk :: DatabasePoly k v -> Id -> k -> v -> IO ()
 setDisk = journal


### PR DESCRIPTION
This space leak arises when using reverse deps to avoid work in HLS, but it doesn't seem to impact regular HLS using regular Shake

# Before
I used a cost centre profile to track the leak:
<img width="1406" alt="Screenshot 2021-06-20 at 19 20 35" src="https://user-images.githubusercontent.com/26626/122684318-a11e1880-d1fc-11eb-8be8-44e498c599b4.png">

Then I profiled a non-instrumented binary just to verify that the leak was not an artefact of `-prof`. I could still assume that the culprit was still `modifyAllMem` because the type being leaked is `(,)`.
<img width="1406" alt="Screenshot 2021-06-20 at 19 21 44" src="https://user-images.githubusercontent.com/26626/122684387-07a33680-d1fd-11eb-8ebe-c593f36a191b.png">


# After 
<img width="1414" alt="Screenshot 2021-06-20 at 19 24 04" src="https://user-images.githubusercontent.com/26626/122684400-1ab60680-d1fd-11eb-9f87-b0e070d1dcc8.png">

