### PR TITLE
Add (failing) test for not hashing when we shouldn't

### DIFF
--- a/src/Development/Shake.hs
+++ b/src/Development/Shake.hs
@@ -59,7 +59,7 @@ module Development.Shake(
     -- * Configuration
     ShakeOptions(..), Rebuild(..), Lint(..), Change(..),
     getShakeOptions, getShakeOptionsRules, getHashedShakeVersion,
-    getShakeExtra, getShakeExtraRules, addShakeExtra,
+    getShakeExtra, getShakeExtraRules, addShakeExtra, FileHash,
     -- ** Command line
     shakeArgs, shakeArgsWith, shakeArgsOptionsWith, shakeOptDescrs, addHelpSuffix,
     -- ** Targets

--- a/src/Development/Shake/Internal/Rules/File.hs
+++ b/src/Development/Shake/Internal/Rules/File.hs
@@ -146,13 +146,17 @@ data EqualCost
       deriving (Eq,Ord,Show,Read,Typeable,Enum,Bounded)
 
 fileStoredValue :: ShakeOptions -> FileQ -> IO (Maybe FileA)
-fileStoredValue ShakeOptions{shakeChange=c, shakeNeedDirectory=allowDir} (FileQ x) = do
+fileStoredValue ShakeOptions{shakeChange=c, shakeNeedDirectory=allowDir
+                            , shakeTraceHashFile=traceHashFile} (FileQ x) = do
     res <- getFileInfo allowDir x
     case res of
         Nothing -> pure Nothing
         Just (time,size) | c == ChangeModtime -> pure $ Just $ FileA time size noFileHash
         Just (time,size) -> do
-            hash <- unsafeInterleaveIO $ getFileHash x
+            hash <- unsafeInterleaveIO $ do
+              hash <- getFileHash x
+              traceHashFile (fileNameToString x) hash
+              pure hash
             pure $ Just $ FileA time size hash
 
 


### PR DESCRIPTION
Hi,

I believe there is a bug in the logic for deciding whether to hash, and I believe these changes demonstrate it.

I've added a `shakeTraceHashFile :: FilePath -> FileHash -> IO ()` to `ShakeOptions` and I call this from inside the `unsafeInterleaveIO` that hashes the file. The digest test maintains an `IORef (HashMap FilePath FileHash)` and asserts it empty after build which should not hash anything(according to the comment).

This is a rough patch, but lmk what you think.    
