### PR TITLE
Fix profile build

### DIFF
--- a/src/Development/Shake/Internal/FilePattern.hs
+++ b/src/Development/Shake/Internal/FilePattern.hs
@@ -104,7 +104,9 @@ parseLit x = case split (== '*') x of
 
 internalTest :: IO ()
 internalTest = do
-    let x # y = when (parse x /= y) $ fail $ show ("FilePattern.internalTest",x,parse x,y)
+    let x # y =
+            let p = parse x
+            in when (p /= y) $ fail $ show ("FilePattern.internalTest",x,p,y)
     "" # [Lit ""]
     "x" # [Lit "x"]
     "/" # [Lit "",Lit ""]


### PR DESCRIPTION
Without this it is impossible to build `shake` with profiling enabled:

```
% stack build --profile .
Building all executables for `shake' once. After a successful build of all of them, only specified executables will be rebuilt.
shake> build (lib + exe)
Preprocessing library for shake-0.19.6..
Building library for shake-0.19.6..
[41 of 73] Compiling Development.Shake.Internal.FilePattern
Simplifier ticks exhausted
  When trying UnfoldingDone $s#_sapx
  To increase the limit, use -fsimpl-tick-factor=N (default 100).

  If you need to increase the limit substantially, please file a
  bug report and indicate the factor you needed.

  If GHC was unable to complete compilation even with a very large factor
  (a thousand or more), please consult the "Known bugs or infelicities"
  section in the Users Guide before filing a report. There are a
  few situations unlikely to occur in practical programs for which
  simplifier non-termination has been judged acceptable.

  To see detailed counts use -ddump-simpl-stats
  Total ticks: 171006
```