### PR TITLE
doesFileExist_ == True for broken symlinks

### DIFF
--- a/src/General/Extra.hs
+++ b/src/General/Extra.hs
@@ -232,7 +232,7 @@ handleSynchronous = handleBool (not . isAsyncException)
 -- System.Directory
 
 doesFileExist_ :: FilePath -> IO Bool
-doesFileExist_ x = doesFileExist x `catchIO` \_ -> pure False
+doesFileExist_ x = (||) <$> doesFileExist x <*> pathIsSymbolicLink x `catchIO` \_ -> pure False
 
 doesDirectoryExist_ :: FilePath -> IO Bool
 doesDirectoryExist_ x = doesDirectoryExist x `catchIO` \_ -> pure False


### PR DESCRIPTION
I wanted pass the symlink to `produces`, intending to make the target file of the symlink afterwards, but got error: `Files declared by produces not produced:`.

This pull request will let me `produces` broken symlink.