### PR TITLE
Add a flag "threaded" for building the executable with the threaded RTS

### DIFF
--- a/shake.cabal
+++ b/shake.cabal
@@ -81,6 +81,11 @@ flag embed-files
     manual: True
     description: Embed data files into the shake library
 
+flag threaded
+    default: True
+    manual: True
+    description: Build shake with the threaded RTS
+
 library
     default-language: Haskell2010
     hs-source-dirs:   src
@@ -205,7 +210,9 @@ library
 executable shake
     default-language: Haskell2010
     hs-source-dirs:   src
-    ghc-options: -main-is Run.main -rtsopts -threaded "-with-rtsopts=-I0 -qg"
+    ghc-options: -main-is Run.main -rtsopts
+    if flag(threaded)
+        ghc-options: -threaded "-with-rtsopts=-I0 -qg"
     main-is: Run.hs
     build-depends:
         base == 4.*,
@@ -328,7 +335,9 @@ test-suite shake-test
     type: exitcode-stdio-1.0
     main-is: Test.hs
     hs-source-dirs: src
-    ghc-options: -main-is Test.main -rtsopts -with-rtsopts=-K1K -threaded
+    ghc-options: -main-is Test.main -rtsopts -with-rtsopts=-K1K
+    if flag(threaded)
+        ghc-options: -threaded
 
     build-depends:
         base == 4.*,


### PR DESCRIPTION
GHC isn't guaranteed to have a threaded RTS. There should be a way to build it with the vanilla one.