### PR TITLE
Require filepath >= 1.4

### DIFF
--- a/shake.cabal
+++ b/shake.cabal
@@ -91,7 +91,7 @@ library
         deepseq >= 1.1,
         directory >= 1.2.7.0,
         extra >= 1.6.19,
-        filepath,
+        filepath >= 1.4,
         filepattern,
         hashable >= 1.1.2.3,
         heaps >= 0.3.6.1,


### PR DESCRIPTION
Otherwise build can fail with 
```
src/Development/Shake/Command.hs:464:35: error:
    • Variable not in scope: (-<.>) :: Bool -> String -> Bool
    • Perhaps you meant ‘<.>’ (imported from Development.Shake.FilePath)
    |
464 |     let progExe = if prog == prog -<.> exe then prog else prog <.> exe
    |                                   ^^^^
```

As a Hackage trustee I made revisions to affected releases of `shake`.